### PR TITLE
Add imperative dev dependency

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
 registry=http://registry.npmjs.org/
-@brightside:registry=https://gizaartifactory.jfrog.io/gizaartifactory/api/npm/npm-release/
-# @brightside:registry=https://api.bintray.com/npm/ca/brightside/
+# @brightside:registry=https://gizaartifactory.jfrog.io/gizaartifactory/api/npm/npm-release/
+@brightside:registry=https://api.bintray.com/npm/ca/brightside/
 package-lock=false

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -298,7 +298,6 @@ pipeline {
             steps {
                 timeout(time: 10, unit: 'MINUTES') {
                     echo 'Installing Dependencies'
-                    sh "rm -f .npmrc"
                     sh "npm install"
                 }
             }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "xml2js": "0.4.19"
   },
   "devDependencies": {
+    "@brightside/imperative": ">=2.0.0-0",
     "@types/jest": "^20.0.5",
     "@types/node": "^8.0.0",
     "@types/xml2js": "^0.4.3",
@@ -115,6 +116,6 @@
   "license": "EPL-2.0",
   "peerDependencies": {
     "@brightside/core": "1.x",
-    "@brightside/imperative": "1.x"
+    "@brightside/imperative": ">=2.0.0-0"
   }
 }


### PR DESCRIPTION
Add a dev dependency on @brightside/imperative so that `npm run build` can function without the symbolic link script

Used the same version as is currently used by Zowe CLI

Fixes #8 