### PR TITLE
Attempt to support CMCI through HTTPS

### DIFF
--- a/__tests__/__resources__/properties/example_properties.yaml
+++ b/__tests__/__resources__/properties/example_properties.yaml
@@ -17,9 +17,11 @@
 
 #  see bright profiles create cics --help for more info
 cmci:
-      user: my-user-name
-      password: my-password
-      host: my-cics-host
-      port: my-cics-port
-      csdGroup: my-csd-group
-      regionName: my-region-name
+  user: my-user-name
+  password: my-password
+  host: my-cics-host
+  port: my-cics-port
+  csdGroup: my-csd-group
+  regionName: my-region-name
+  protocol: http
+  rejectUnauthorized: false

--- a/__tests__/__snapshots__/imperative.test.ts.snap
+++ b/__tests__/__snapshots__/imperative.test.ts.snap
@@ -67,6 +67,27 @@ Object {
             },
             "type": "number",
           },
+          "protocol": Object {
+            "optionDefinition": Object {
+              "aliases": Array [
+                "o",
+              ],
+              "allowableValues": Object {
+                "caseSensitive": false,
+                "values": Array [
+                  "http",
+                  "https",
+                ],
+              },
+              "defaultValue": "http",
+              "description": "Specifies CMCI protocol (http or https).",
+              "group": "Cics Connection Options",
+              "name": "protocol",
+              "required": true,
+              "type": "string",
+            },
+            "type": "string",
+          },
           "regionName": Object {
             "optionDefinition": Object {
               "description": "The name of the CICS region name to interact with",
@@ -74,6 +95,20 @@ Object {
               "type": "string",
             },
             "type": "string",
+          },
+          "rejectUnauthorized": Object {
+            "optionDefinition": Object {
+              "aliases": Array [
+                "ru",
+              ],
+              "defaultValue": true,
+              "description": "Reject self-signed certificates.",
+              "group": "Cics Connection Options",
+              "name": "reject-unauthorized",
+              "required": false,
+              "type": "boolean",
+            },
+            "type": "boolean",
           },
           "user": Object {
             "optionDefinition": Object {

--- a/__tests__/__src__/environment/TempTestProfiles.ts
+++ b/__tests__/__src__/environment/TempTestProfiles.ts
@@ -86,10 +86,16 @@ export class TempTestProfiles {
     private static async createCicsProfile(testEnvironment: ITestEnvironment) {
         const profileName: string = "tmp_cics" + uuidv4();
         const cmciProps = testEnvironment.systemTestProperties.cmci;
-        const createProfileScript = TemporaryScripts.SHEBANG +
+        let createProfileScript = TemporaryScripts.SHEBANG +
             `${TemporaryScripts.BRIGHT_BIN} profiles create cics ${profileName} --user ${cmciProps.user} -p ` +
             `${cmciProps.password} ` +
             ` --host ${cmciProps.host} --port ${cmciProps.port}`;
+        if (cmciProps.protocol != null) {
+            createProfileScript += ` --protocol ${cmciProps.protocol}`;
+        }
+        if (cmciProps.rejectUnauthorized != null) {
+            createProfileScript += ` --reject-unauthorized ${cmciProps.rejectUnauthorized}`;
+        }
 
         const scriptPath = testEnvironment.workingDir + "_create_profile_" + profileName;
         await IO.writeFileAsync(scriptPath, createProfileScript);
@@ -97,9 +103,9 @@ export class TempTestProfiles {
         if (output.status !== 0 || output.stderr.toString().trim().length > 0) {
             throw new ImperativeError({
                 msg: "Creation of cics profile '" + profileName + "' failed! You should delete the script: \n'" + scriptPath + "' " +
-                "after reviewing it to check for possible errors.\n Output of the profile create command:\n" + output.stderr.toString() +
-                output.stdout.toString() +
-                TempTestProfiles.GLOBAL_INSTALL_NOTE
+                    "after reviewing it to check for possible errors.\n Output of the profile create command:\n" + output.stderr.toString() +
+                    output.stdout.toString() +
+                    TempTestProfiles.GLOBAL_INSTALL_NOTE
             });
         }
         IO.deleteFile(scriptPath);
@@ -123,8 +129,8 @@ export class TempTestProfiles {
         if (output.status !== 0 || output.stderr.toString().trim().length > 0) {
             throw new ImperativeError({
                 msg: "Deletion of " + profileType + " profile '" + profileName + "' failed! You should delete the script: '" + scriptPath + "' " +
-                "after reviewing it to check for possible errors. Stderr of the profile create command:\n" + output.stderr.toString()
-                + TempTestProfiles.GLOBAL_INSTALL_NOTE
+                    "after reviewing it to check for possible errors. Stderr of the profile create command:\n" + output.stderr.toString()
+                    + TempTestProfiles.GLOBAL_INSTALL_NOTE
             });
         }
         this.log(testEnvironment, `Deleted ${profileType} profile '${profileName}'. Stdout from deletion:\n${output.stdout.toString()}`);

--- a/__tests__/__src__/environment/doc/ITestPropertiesSchema.ts
+++ b/__tests__/__src__/environment/doc/ITestPropertiesSchema.ts
@@ -15,40 +15,45 @@
  */
 export interface ITestPropertiesSchema {
 
-  /**
-   * Properties related to connecting to CMCI
-   */
-  cmci: {
     /**
-     * user ID to connect to CMCI
+     * Properties related to connecting to CMCI
      */
-    user: string,
-    /**
-     * Password to connect to CMCI
-     */
-    password: string,
-    /**
-     * host name for  CMCI
-     */
-    host: string,
-    /**
-     * Port for CMCI
-     */
-    port?: number,
-    /**
-     * CSD group to define resources to
-     */
-    csdGroup?: string;
+    cmci: {
+        /**
+         * user ID to connect to CMCI
+         */
+        user: string,
+        /**
+         * Password to connect to CMCI
+         */
+        password: string,
+        /**
+         * host name for  CMCI
+         */
+        host: string,
+        /**
+         * Port for CMCI
+         */
+        port?: number,
+        /**
+         * CSD group to define resources to
+         */
+        csdGroup?: string;
 
-    /**
-     * Name of the CICS region e.g. "CICSCMCI"
-     */
-    regionName?: string;
+        /**
+         * Name of the CICS region e.g. "CICSCMCI"
+         */
+        regionName?: string;
 
-    /**
-     * http or https protocol for CMCI
-     */
-    protocol?: string;
-  };
+        /**
+         * http or https protocol for CMCI
+         */
+        protocol?: string;
+
+        /**
+         * http or https protocol for CMCI
+         */
+        rejectUnauthorized?: boolean;
+    };
 
 }

--- a/__tests__/__src__/environment/doc/ITestPropertiesSchema.ts
+++ b/__tests__/__src__/environment/doc/ITestPropertiesSchema.ts
@@ -15,35 +15,40 @@
  */
 export interface ITestPropertiesSchema {
 
+  /**
+   * Properties related to connecting to CMCI
+   */
+  cmci: {
     /**
-     * Properties related to connecting to CMCI
+     * user ID to connect to CMCI
      */
-    cmci: {
-        /**
-         * user ID to connect to CMCI
-         */
-        user: string,
-        /**
-         * Password to connect to CMCI
-         */
-        password: string,
-        /**
-         * host name for  CMCI
-         */
-        host: string,
-        /**
-         * Port for CMCI
-         */
-        port?: number,
-        /**
-         * CSD group to define resources to
-         */
-        csdGroup?: string;
+    user: string,
+    /**
+     * Password to connect to CMCI
+     */
+    password: string,
+    /**
+     * host name for  CMCI
+     */
+    host: string,
+    /**
+     * Port for CMCI
+     */
+    port?: number,
+    /**
+     * CSD group to define resources to
+     */
+    csdGroup?: string;
 
-        /**
-         * Name of the CICS region e.g. "CICSCMCI"
-         */
-        regionName?: string;
-    };
+    /**
+     * Name of the CICS region e.g. "CICSCMCI"
+     */
+    regionName?: string;
+
+    /**
+     * http or https protocol for CMCI
+     */
+    protocol?: string;
+  };
 
 }

--- a/__tests__/__system__/api/methods/define/Define.program.system.test.ts
+++ b/__tests__/__system__/api/methods/define/Define.program.system.test.ts
@@ -22,112 +22,112 @@ let session: Session;
 
 describe("CICS Define program", () => {
 
-    beforeAll(async () => {
-        testEnvironment = await TestEnvironment.setUp({
-            testName: "cics_cmci_define_program",
-            installPlugin: true,
-            tempProfileTypes: ["cics"]
-        });
-        csdGroup = testEnvironment.systemTestProperties.cmci.csdGroup;
-        regionName = testEnvironment.systemTestProperties.cmci.regionName;
-        const cmciProperties = await testEnvironment.systemTestProperties.cmci;
-
-        session = new Session({
-            user: cmciProperties.user,
-            password: cmciProperties.password,
-            hostname: cmciProperties.host,
-            port: cmciProperties.port,
-            type: "basic",
-            strictSSL: false,
-            protocol: "http",
-        });
+  beforeAll(async () => {
+    testEnvironment = await TestEnvironment.setUp({
+      testName: "cics_cmci_define_program",
+      installPlugin: true,
+      tempProfileTypes: ["cics"]
     });
+    csdGroup = testEnvironment.systemTestProperties.cmci.csdGroup;
+    regionName = testEnvironment.systemTestProperties.cmci.regionName;
+    const cmciProperties = await testEnvironment.systemTestProperties.cmci;
 
-    afterAll(async () => {
-        await TestEnvironment.cleanUp(testEnvironment);
+    session = new Session({
+      user: cmciProperties.user,
+      password: cmciProperties.password,
+      hostname: cmciProperties.host,
+      port: cmciProperties.port,
+      type: "basic",
+      strictSSL: false,
+      protocol: testEnvironment.systemTestProperties.cmci.protocol as any || "http",
     });
+  });
 
-    const options: IProgramParms = {} as any;
+  afterAll(async () => {
+    await TestEnvironment.cleanUp(testEnvironment);
+  });
 
-    it("should define a program to CICS", async () => {
-        let error;
-        let response;
+  const options: IProgramParms = {} as any;
 
-        const programNameSuffixLength = 4;
-        const programName = "AAAA" + generateRandomAlphaNumericString(programNameSuffixLength);
+  it("should define a program to CICS", async () => {
+    let error;
+    let response;
 
-        options.name = programName;
-        options.csdGroup = csdGroup;
-        options.regionName = regionName;
+    const programNameSuffixLength = 4;
+    const programName = "AAAA" + generateRandomAlphaNumericString(programNameSuffixLength);
 
-        try {
-            response = await defineProgram(session, options);
-        } catch (err) {
-            error = err;
-        }
+    options.name = programName;
+    options.csdGroup = csdGroup;
+    options.regionName = regionName;
 
-        expect(error).toBeFalsy();
-        expect(response).toBeTruthy();
-        expect(response.response.resultsummary.api_response1).toBe("1024");
-        await deleteProgram(session, options);
-    });
+    try {
+      response = await defineProgram(session, options);
+    } catch (err) {
+      error = err;
+    }
 
-    it("should fail to define a program to CICS with invalid CICS region", async () => {
-        let error;
-        let response;
+    expect(error).toBeFalsy();
+    expect(response).toBeTruthy();
+    expect(response.response.resultsummary.api_response1).toBe("1024");
+    await deleteProgram(session, options);
+  });
 
-        const programNameSuffixLength = 4;
-        const programName = "AAAA" + generateRandomAlphaNumericString(programNameSuffixLength);
+  it("should fail to define a program to CICS with invalid CICS region", async () => {
+    let error;
+    let response;
 
-        options.name = programName;
-        options.csdGroup = csdGroup;
-        options.regionName = "FAKE";
+    const programNameSuffixLength = 4;
+    const programName = "AAAA" + generateRandomAlphaNumericString(programNameSuffixLength);
 
-        try {
-            response = await defineProgram(session, options);
-        } catch (err) {
-            error = err;
-        }
+    options.name = programName;
+    options.csdGroup = csdGroup;
+    options.regionName = "FAKE";
 
-        expect(error).toBeTruthy();
-        expect(response).toBeFalsy();
-        expect(error.message).toContain("Did not receive the expected response from CMCI REST API");
-        expect(error.message).toContain("INVALIDPARM");
-    });
+    try {
+      response = await defineProgram(session, options);
+    } catch (err) {
+      error = err;
+    }
 
-    it("should fail to define a program to CICS due to duplicate name", async () => {
-        let error;
-        let response;
+    expect(error).toBeTruthy();
+    expect(response).toBeFalsy();
+    expect(error.message).toContain("Did not receive the expected response from CMCI REST API");
+    expect(error.message).toContain("INVALIDPARM");
+  });
 
-        const programNameSuffixLength = 4;
-        const programName = "AAAA" + generateRandomAlphaNumericString(programNameSuffixLength);
+  it("should fail to define a program to CICS due to duplicate name", async () => {
+    let error;
+    let response;
 
-        options.name = programName;
-        options.csdGroup = csdGroup;
-        options.regionName = regionName;
+    const programNameSuffixLength = 4;
+    const programName = "AAAA" + generateRandomAlphaNumericString(programNameSuffixLength);
 
-        // define a program to CICS
-        try {
-            response = await defineProgram(session, options);
-        } catch (err) {
-            error = err;
-        }
+    options.name = programName;
+    options.csdGroup = csdGroup;
+    options.regionName = regionName;
 
-        expect(error).toBeFalsy();
-        expect(response).toBeTruthy();
-        response = null; // reset
+    // define a program to CICS
+    try {
+      response = await defineProgram(session, options);
+    } catch (err) {
+      error = err;
+    }
 
-        // define the same program and validate duplicate error
-        try {
-            response = await defineProgram(session, options);
-        } catch (err) {
-            error = err;
-        }
+    expect(error).toBeFalsy();
+    expect(response).toBeTruthy();
+    response = null; // reset
 
-        expect(error).toBeTruthy();
-        expect(response).toBeFalsy();
-        expect(error.message).toContain("Did not receive the expected response from CMCI REST API");
-        expect(error.message).toContain("DUPRES");
-        await deleteProgram(session, options);
-    });
+    // define the same program and validate duplicate error
+    try {
+      response = await defineProgram(session, options);
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeTruthy();
+    expect(response).toBeFalsy();
+    expect(error.message).toContain("Did not receive the expected response from CMCI REST API");
+    expect(error.message).toContain("DUPRES");
+    await deleteProgram(session, options);
+  });
 });

--- a/__tests__/__system__/api/methods/define/Define.transaction.system.test.ts
+++ b/__tests__/__system__/api/methods/define/Define.transaction.system.test.ts
@@ -39,7 +39,7 @@ describe("CICS Define transaction", () => {
             port: cmciProperties.port,
             type: "basic",
             strictSSL: false,
-            protocol: "http",
+            protocol: testEnvironment.systemTestProperties.cmci.protocol as any || "http",
         });
     });
 

--- a/__tests__/__system__/api/methods/delete/Delete.program.system.test.ts
+++ b/__tests__/__system__/api/methods/delete/Delete.program.system.test.ts
@@ -39,7 +39,7 @@ describe("CICS Delete program", () => {
             port: cmciProperties.port,
             type: "basic",
             strictSSL: false,
-            protocol: "http",
+            protocol:  testEnvironment.systemTestProperties.cmci.protocol as any || "http",
         });
     });
 

--- a/__tests__/__system__/api/methods/delete/Delete.transaction.system.test.ts
+++ b/__tests__/__system__/api/methods/delete/Delete.transaction.system.test.ts
@@ -39,7 +39,7 @@ describe("CICS Delete transaction", () => {
             port: cmciProperties.port,
             type: "basic",
             strictSSL: false,
-            protocol: "http",
+            protocol:  testEnvironment.systemTestProperties.cmci.protocol as any || "http",
         });
     });
 

--- a/__tests__/__system__/api/methods/discard/Discard.program.system.test.ts
+++ b/__tests__/__system__/api/methods/discard/Discard.program.system.test.ts
@@ -39,7 +39,7 @@ describe("CICS Discard program", () => {
             port: cmciProperties.port,
             type: "basic",
             strictSSL: false,
-            protocol: "http",
+            protocol:  testEnvironment.systemTestProperties.cmci.protocol as any || "http",
         });
     });
 

--- a/__tests__/__system__/api/methods/discard/Discard.transaction.system.test.ts
+++ b/__tests__/__system__/api/methods/discard/Discard.transaction.system.test.ts
@@ -39,7 +39,7 @@ describe("CICS Discard transaction", () => {
             port: cmciProperties.port,
             type: "basic",
             strictSSL: false,
-            protocol: "http",
+            protocol:  testEnvironment.systemTestProperties.cmci.protocol as any || "http",
         });
     });
 

--- a/__tests__/__system__/api/methods/get/Get.resource.system.test.ts
+++ b/__tests__/__system__/api/methods/get/Get.resource.system.test.ts
@@ -36,7 +36,7 @@ describe("CICS Get resource", () => {
             port: cmciProperties.port,
             type: "basic",
             strictSSL: false,
-            protocol: "http",
+            protocol:  testEnvironment.systemTestProperties.cmci.protocol as any || "http",
         });
     });
 

--- a/__tests__/__system__/api/methods/install/Install.program.system.test.ts
+++ b/__tests__/__system__/api/methods/install/Install.program.system.test.ts
@@ -39,7 +39,7 @@ describe("CICS Install program", () => {
             port: cmciProperties.port,
             type: "basic",
             strictSSL: false,
-            protocol: "http",
+            protocol:  testEnvironment.systemTestProperties.cmci.protocol as any || "http",
         });
     });
 

--- a/__tests__/__system__/api/methods/install/Install.transaction.system.test.ts
+++ b/__tests__/__system__/api/methods/install/Install.transaction.system.test.ts
@@ -41,7 +41,7 @@ describe("CICS Install transaction", () => {
             port: cmciProperties.port,
             type: "basic",
             strictSSL: false,
-            protocol: "http",
+            protocol:  testEnvironment.systemTestProperties.cmci.protocol as any || "http",
         });
     });
 

--- a/__tests__/__system__/api/methods/refresh/Refresh.program.system.test.ts
+++ b/__tests__/__system__/api/methods/refresh/Refresh.program.system.test.ts
@@ -39,7 +39,7 @@ describe("CICS Refresh program", () => {
             port: cmciProperties.port,
             type: "basic",
             strictSSL: false,
-            protocol: "http",
+            protocol:  testEnvironment.systemTestProperties.cmci.protocol as any || "http",
         });
     });
 

--- a/__tests__/__system__/cli/define/program/__scripts__/define_program_fully_qualified.sh
+++ b/__tests__/__system__/cli/define/program/__scripts__/define_program_fully_qualified.sh
@@ -8,5 +8,6 @@ HOST=$4
 PORT=$5
 USER=$6
 PASSWORD=$7
-
-zowe cics define program "$program_name" "$csd_group" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD
+PROTOCOL=$8
+REJECT=$9
+zowe cics define program "$program_name" "$csd_group" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"

--- a/__tests__/__system__/cli/define/program/__snapshots__/cli.define.program.system.test.ts.snap
+++ b/__tests__/__system__/cli/define/program/__snapshots__/cli.define.program.system.test.ts.snap
@@ -62,6 +62,19 @@ exports[`CICS define program command should be able to display the help 1`] = `
 
       Mainframe (CICS) password, which can be the same as your TSO password.
 
+   --reject-unauthorized  | --ru (boolean)
+
+      Reject self-signed certificates.
+
+      Default value: true
+
+   --protocol  | -o (string)
+
+      Specifies CMCI protocol (http or https).
+
+      Default value: http
+      Allowed values: http, https
+
  PROFILE OPTIONS
  ---------------
 

--- a/__tests__/__system__/cli/define/program/cli.define.program.system.test.ts
+++ b/__tests__/__system__/cli/define/program/cli.define.program.system.test.ts
@@ -22,7 +22,8 @@ let host: string;
 let port: number;
 let user: string;
 let password: string;
-
+let protocol: string;
+let rejectUnauthorized: boolean;
 describe("CICS define program command", () => {
 
     beforeAll(async () => {
@@ -37,6 +38,8 @@ describe("CICS define program command", () => {
         port = TEST_ENVIRONMENT.systemTestProperties.cmci.port;
         user = TEST_ENVIRONMENT.systemTestProperties.cmci.user;
         password = TEST_ENVIRONMENT.systemTestProperties.cmci.password;
+        protocol = TEST_ENVIRONMENT.systemTestProperties.cmci.protocol;
+        rejectUnauthorized = TEST_ENVIRONMENT.systemTestProperties.cmci.rejectUnauthorized;
     });
 
     afterAll(async () => {
@@ -105,7 +108,9 @@ describe("CICS define program command", () => {
                 host,
                 port,
                 user,
-                password]);
+                password,
+                protocol,
+                rejectUnauthorized]);
         const stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);

--- a/__tests__/__system__/cli/define/transaction/__scripts__/define_transaction_fully_qualified.sh
+++ b/__tests__/__system__/cli/define/transaction/__scripts__/define_transaction_fully_qualified.sh
@@ -9,5 +9,6 @@ HOST=$5
 PORT=$6
 USER=$7
 PASSWORD=$8
-
-zowe cics define transaction "$transaction_name" "$program_name" "$csd_group" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD
+PROTOCOL=$9
+REJECT="${10}"
+zowe cics define transaction "$transaction_name" "$program_name" "$csd_group" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"

--- a/__tests__/__system__/cli/define/transaction/__snapshots__/cli.define.transaction.system.test.ts.snap
+++ b/__tests__/__system__/cli/define/transaction/__snapshots__/cli.define.transaction.system.test.ts.snap
@@ -67,6 +67,19 @@ exports[`CICS define transaction command should be able to display the help 1`] 
 
       Mainframe (CICS) password, which can be the same as your TSO password.
 
+   --reject-unauthorized  | --ru (boolean)
+
+      Reject self-signed certificates.
+
+      Default value: true
+
+   --protocol  | -o (string)
+
+      Specifies CMCI protocol (http or https).
+
+      Default value: http
+      Allowed values: http, https
+
  PROFILE OPTIONS
  ---------------
 

--- a/__tests__/__system__/cli/define/transaction/cli.define.transaction.system.test.ts
+++ b/__tests__/__system__/cli/define/transaction/cli.define.transaction.system.test.ts
@@ -22,7 +22,8 @@ let host: string;
 let port: number;
 let user: string;
 let password: string;
-
+let protocol: string;
+let rejectUnauthorized: boolean;
 describe("CICS define transaction command", () => {
 
     beforeAll(async () => {
@@ -37,6 +38,8 @@ describe("CICS define transaction command", () => {
         port = TEST_ENVIRONMENT.systemTestProperties.cmci.port;
         user = TEST_ENVIRONMENT.systemTestProperties.cmci.user;
         password = TEST_ENVIRONMENT.systemTestProperties.cmci.password;
+        protocol = TEST_ENVIRONMENT.systemTestProperties.cmci.protocol;
+        rejectUnauthorized = TEST_ENVIRONMENT.systemTestProperties.cmci.rejectUnauthorized;
     });
 
     afterAll(async () => {
@@ -122,7 +125,9 @@ describe("CICS define transaction command", () => {
                 host,
                 port,
                 user,
-                password]);
+                password,
+                protocol,
+                rejectUnauthorized]);
         const stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);

--- a/__tests__/__system__/cli/define/transaction/cli.define.transaction.system.test.ts
+++ b/__tests__/__system__/cli/define/transaction/cli.define.transaction.system.test.ts
@@ -13,7 +13,7 @@ import { TestEnvironment } from "../../../../__src__/environment/TestEnvironment
 import { ITestEnvironment } from "../../../../__src__/environment/doc/response/ITestEnvironment";
 import { generateRandomAlphaNumericString, runCliScript } from "../../../../__src__/TestUtils";
 import { Session } from "@brightside/imperative";
-import { CicsCmciRestClient, CicsCmciConstants } from "../../../../../src";
+import { CicsCmciConstants, CicsCmciRestClient } from "../../../../../src";
 
 let TEST_ENVIRONMENT: ITestEnvironment;
 let regionName: string;
@@ -52,7 +52,7 @@ describe("CICS define transaction command", () => {
             user: cmciProperties.user,
             password: cmciProperties.password,
             strictSSL: false,
-            protocol: "http",
+            protocol: cmciProperties.protocol as any || "http",
         });
 
         return CicsCmciRestClient.deleteExpectParsedXml(session,

--- a/__tests__/__system__/cli/delete/program/__scripts__/delete_program_fully_qualified.sh
+++ b/__tests__/__system__/cli/delete/program/__scripts__/delete_program_fully_qualified.sh
@@ -8,5 +8,6 @@ HOST=$4
 PORT=$5
 USER=$6
 PASSWORD=$7
-
-zowe cics delete program "$program_name" "$csd_group" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD
+PROTOCOL=$8
+REJECT=$9
+zowe cics delete program "$program_name" "$csd_group" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol $PROTOCOL --reject-unauthorized $REJECT

--- a/__tests__/__system__/cli/delete/program/__snapshots__/cli.delete.program.system.test.ts.snap
+++ b/__tests__/__system__/cli/delete/program/__snapshots__/cli.delete.program.system.test.ts.snap
@@ -62,6 +62,19 @@ exports[`CICS delete program command should be able to display the help 1`] = `
 
       Mainframe (CICS) password, which can be the same as your TSO password.
 
+   --reject-unauthorized  | --ru (boolean)
+
+      Reject self-signed certificates.
+
+      Default value: true
+
+   --protocol  | -o (string)
+
+      Specifies CMCI protocol (http or https).
+
+      Default value: http
+      Allowed values: http, https
+
  PROFILE OPTIONS
  ---------------
 

--- a/__tests__/__system__/cli/delete/program/cli.delete.program.system.test.ts
+++ b/__tests__/__system__/cli/delete/program/cli.delete.program.system.test.ts
@@ -20,7 +20,8 @@ let host: string;
 let port: number;
 let user: string;
 let password: string;
-
+let protocol: string;
+let rejectUnauthorized: boolean;
 describe("CICS delete program command", () => {
 
     beforeAll(async () => {
@@ -35,6 +36,8 @@ describe("CICS delete program command", () => {
         port = TEST_ENVIRONMENT.systemTestProperties.cmci.port;
         user = TEST_ENVIRONMENT.systemTestProperties.cmci.user;
         password = TEST_ENVIRONMENT.systemTestProperties.cmci.password;
+        protocol = TEST_ENVIRONMENT.systemTestProperties.cmci.protocol;
+        rejectUnauthorized = TEST_ENVIRONMENT.systemTestProperties.cmci.rejectUnauthorized;
     });
 
     afterAll(async () => {
@@ -93,7 +96,9 @@ describe("CICS delete program command", () => {
                 host,
                 port,
                 user,
-                password]);
+                password,
+                protocol,
+                rejectUnauthorized]);
         let stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
@@ -106,7 +111,9 @@ describe("CICS delete program command", () => {
                 host,
                 port,
                 user,
-                password]);
+                password,
+                protocol,
+                rejectUnauthorized]);
         stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);

--- a/__tests__/__system__/cli/delete/transaction/__scripts__/delete_transaction_fully_qualified.sh
+++ b/__tests__/__system__/cli/delete/transaction/__scripts__/delete_transaction_fully_qualified.sh
@@ -8,5 +8,6 @@ HOST=$4
 PORT=$5
 USER=$6
 PASSWORD=$7
-
-zowe cics delete transaction "$transaction_name" "$csd_group" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD
+PROTOCOL=$8
+REJECT=$9
+zowe cics delete transaction "$transaction_name" "$csd_group" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"

--- a/__tests__/__system__/cli/delete/transaction/__snapshots__/cli.delete.transaction.system.test.ts.snap
+++ b/__tests__/__system__/cli/delete/transaction/__snapshots__/cli.delete.transaction.system.test.ts.snap
@@ -62,6 +62,19 @@ exports[`CICS delete transaction command should be able to display the help 1`] 
 
       Mainframe (CICS) password, which can be the same as your TSO password.
 
+   --reject-unauthorized  | --ru (boolean)
+
+      Reject self-signed certificates.
+
+      Default value: true
+
+   --protocol  | -o (string)
+
+      Specifies CMCI protocol (http or https).
+
+      Default value: http
+      Allowed values: http, https
+
  PROFILE OPTIONS
  ---------------
 

--- a/__tests__/__system__/cli/delete/transaction/cli.delete.transaction.system.test.ts
+++ b/__tests__/__system__/cli/delete/transaction/cli.delete.transaction.system.test.ts
@@ -21,6 +21,8 @@ let host: string;
 let port: number;
 let user: string;
 let password: string;
+let protocol: string;
+let rejectUnauthorized: boolean;
 
 describe("CICS delete transaction command", () => {
 
@@ -36,6 +38,8 @@ describe("CICS delete transaction command", () => {
         port = TEST_ENVIRONMENT.systemTestProperties.cmci.port;
         user = TEST_ENVIRONMENT.systemTestProperties.cmci.user;
         password = TEST_ENVIRONMENT.systemTestProperties.cmci.password;
+        protocol = TEST_ENVIRONMENT.systemTestProperties.cmci.protocol;
+        rejectUnauthorized = TEST_ENVIRONMENT.systemTestProperties.cmci.rejectUnauthorized;
     });
 
     afterAll(async () => {
@@ -96,7 +100,9 @@ describe("CICS delete transaction command", () => {
                 host,
                 port,
                 user,
-                password]);
+                password,
+                protocol,
+                rejectUnauthorized]);
         let stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
@@ -109,7 +115,9 @@ describe("CICS delete transaction command", () => {
                 host,
                 port,
                 user,
-                password]);
+                password,
+                protocol,
+                rejectUnauthorized]);
         stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);

--- a/__tests__/__system__/cli/discard/program/__scripts__/discard_program_fully_qualified.sh
+++ b/__tests__/__system__/cli/discard/program/__scripts__/discard_program_fully_qualified.sh
@@ -7,5 +7,6 @@ HOST=$3
 PORT=$4
 USER=$5
 PASSWORD=$6
-
-zowe cics discard program "$program_name" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD
+PROTOCOL=$7
+REJECT=$8
+zowe cics discard program "$program_name" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol $PROTOCOL --reject-unauthorized $REJECT

--- a/__tests__/__system__/cli/discard/program/__snapshots__/cli.discard.program.system.test.ts.snap
+++ b/__tests__/__system__/cli/discard/program/__snapshots__/cli.discard.program.system.test.ts.snap
@@ -57,6 +57,19 @@ exports[`CICS discard program command should be able to display the help 1`] = `
 
       Mainframe (CICS) password, which can be the same as your TSO password.
 
+   --reject-unauthorized  | --ru (boolean)
+
+      Reject self-signed certificates.
+
+      Default value: true
+
+   --protocol  | -o (string)
+
+      Specifies CMCI protocol (http or https).
+
+      Default value: http
+      Allowed values: http, https
+
  PROFILE OPTIONS
  ---------------
 

--- a/__tests__/__system__/cli/discard/program/cli.discard.program.system.test.ts
+++ b/__tests__/__system__/cli/discard/program/cli.discard.program.system.test.ts
@@ -22,6 +22,8 @@ let host: string;
 let port: number;
 let user: string;
 let password: string;
+let protocol: string;
+let rejectUnauthorized: boolean;
 
 describe("CICS discard program command", () => {
 
@@ -37,6 +39,8 @@ describe("CICS discard program command", () => {
         port = TEST_ENVIRONMENT.systemTestProperties.cmci.port;
         user = TEST_ENVIRONMENT.systemTestProperties.cmci.user;
         password = TEST_ENVIRONMENT.systemTestProperties.cmci.password;
+        protocol = TEST_ENVIRONMENT.systemTestProperties.cmci.protocol;
+        rejectUnauthorized = TEST_ENVIRONMENT.systemTestProperties.cmci.rejectUnauthorized;
     });
 
     afterAll(async () => {
@@ -121,7 +125,9 @@ describe("CICS discard program command", () => {
                 host,
                 port,
                 user,
-                password]);
+                password,
+                protocol,
+                rejectUnauthorized]);
         let stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
@@ -135,20 +141,24 @@ describe("CICS discard program command", () => {
                 host,
                 port,
                 user,
-                password]);
+                password,
+                protocol,
+                rejectUnauthorized]);
         stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
         expect(output.stdout.toString()).toContain("success");
 
         output = runCliScript(__dirname + "/__scripts__/discard_program_fully_qualified.sh",
-                 TEST_ENVIRONMENT,
+            TEST_ENVIRONMENT,
             [programName,
                 regionName,
                 host,
                 port,
                 user,
-                password]);
+                password,
+                protocol,
+                rejectUnauthorized]);
         stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);

--- a/__tests__/__system__/cli/discard/transaction/__scripts__/discard_transaction_fully_qualified.sh
+++ b/__tests__/__system__/cli/discard/transaction/__scripts__/discard_transaction_fully_qualified.sh
@@ -3,5 +3,11 @@ set -e # fail the script if we get a non zero exit code
 
 transaction_name=$1
 region_name=$2
+HOST=$3
+PORT=$4
+USER=$5
+PASSWORD=$6
+PROTOCOL=$7
+REJECT=$8
 
-zowe cics discard transaction "$transaction_name" --region-name "$region_name"
+zowe cics discard transaction "$transaction_name" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol $PROTOCOL --reject-unauthorized $REJECT

--- a/__tests__/__system__/cli/discard/transaction/__snapshots__/cli.discard.transaction.system.test.ts.snap
+++ b/__tests__/__system__/cli/discard/transaction/__snapshots__/cli.discard.transaction.system.test.ts.snap
@@ -57,6 +57,19 @@ exports[`CICS discard transaction command should be able to display the help 1`]
 
       Mainframe (CICS) password, which can be the same as your TSO password.
 
+   --reject-unauthorized  | --ru (boolean)
+
+      Reject self-signed certificates.
+
+      Default value: true
+
+   --protocol  | -o (string)
+
+      Specifies CMCI protocol (http or https).
+
+      Default value: http
+      Allowed values: http, https
+
  PROFILE OPTIONS
  ---------------
 

--- a/__tests__/__system__/cli/discard/transaction/cli.discard.transaction.system.test.ts
+++ b/__tests__/__system__/cli/discard/transaction/cli.discard.transaction.system.test.ts
@@ -23,6 +23,8 @@ let host: string;
 let port: number;
 let user: string;
 let password: string;
+let protocol: string;
+let rejectUnauthorized: boolean;
 
 describe("CICS discard transaction command", () => {
 
@@ -38,6 +40,8 @@ describe("CICS discard transaction command", () => {
         port = TEST_ENVIRONMENT.systemTestProperties.cmci.port;
         user = TEST_ENVIRONMENT.systemTestProperties.cmci.user;
         password = TEST_ENVIRONMENT.systemTestProperties.cmci.password;
+        protocol = TEST_ENVIRONMENT.systemTestProperties.cmci.protocol;
+        rejectUnauthorized = TEST_ENVIRONMENT.systemTestProperties.cmci.rejectUnauthorized;
     });
 
     afterAll(async () => {
@@ -123,7 +127,10 @@ describe("CICS discard transaction command", () => {
                 host,
                 port,
                 user,
-                password]);
+                password,
+                protocol,
+                rejectUnauthorized
+            ]);
         let stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
@@ -137,7 +144,9 @@ describe("CICS discard transaction command", () => {
                 host,
                 port,
                 user,
-                password]);
+                password,
+                protocol,
+                rejectUnauthorized]);
         stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
@@ -149,7 +158,9 @@ describe("CICS discard transaction command", () => {
                 host,
                 port,
                 user,
-                password]);
+                password,
+                protocol,
+                rejectUnauthorized]);
         stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);

--- a/__tests__/__system__/cli/get/resource/__scripts__/get_resource_fully_qualified.sh
+++ b/__tests__/__system__/cli/get/resource/__scripts__/get_resource_fully_qualified.sh
@@ -7,5 +7,6 @@ HOST=$3
 PORT=$4
 USER=$5
 PASSWORD=$6
-
-zowe cics get resource "$resource_name" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD
+PROTOCOL=$7
+REJECT=$8
+zowe cics get resource "$resource_name" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol $PROTOCOL --reject-unauthorized $REJECT

--- a/__tests__/__system__/cli/get/resource/__snapshots__/cli.get.resource.system.test.ts.snap
+++ b/__tests__/__system__/cli/get/resource/__snapshots__/cli.get.resource.system.test.ts.snap
@@ -65,6 +65,19 @@ exports[`cics get resource should display the help 1`] = `
 
       Mainframe (CICS) password, which can be the same as your TSO password.
 
+   --reject-unauthorized  | --ru (boolean)
+
+      Reject self-signed certificates.
+
+      Default value: true
+
+   --protocol  | -o (string)
+
+      Specifies CMCI protocol (http or https).
+
+      Default value: http
+      Allowed values: http, https
+
  PROFILE OPTIONS
  ---------------
 

--- a/__tests__/__system__/cli/get/resource/cli.get.resource.system.test.ts
+++ b/__tests__/__system__/cli/get/resource/cli.get.resource.system.test.ts
@@ -37,6 +37,10 @@ describe("cics get resource", () => {
         password = TEST_ENVIRONMENT.systemTestProperties.cmci.password;
     });
 
+    afterAll(async () => {
+        await TestEnvironment.cleanUp(TEST_ENVIRONMENT);
+    });
+
     it("should display the help", async () => {
         const response = await runCliScript(__dirname + "/__scripts__/get_resource_help.sh", TEST_ENVIRONMENT);
         expect(response.stderr.toString()).toBe("");

--- a/__tests__/__system__/cli/get/resource/cli.get.resource.system.test.ts
+++ b/__tests__/__system__/cli/get/resource/cli.get.resource.system.test.ts
@@ -20,6 +20,8 @@ let host: string;
 let port: number;
 let user: string;
 let password: string;
+let protocol: string;
+let rejectUnauthorized: boolean;
 
 describe("cics get resource", () => {
 
@@ -35,6 +37,8 @@ describe("cics get resource", () => {
         port = TEST_ENVIRONMENT.systemTestProperties.cmci.port;
         user = TEST_ENVIRONMENT.systemTestProperties.cmci.user;
         password = TEST_ENVIRONMENT.systemTestProperties.cmci.password;
+        protocol = TEST_ENVIRONMENT.systemTestProperties.cmci.protocol;
+        rejectUnauthorized = TEST_ENVIRONMENT.systemTestProperties.cmci.rejectUnauthorized;
     });
 
     afterAll(async () => {
@@ -65,7 +69,9 @@ describe("cics get resource", () => {
                 host,
                 port,
                 user,
-                password]);
+                password,
+                protocol,
+                rejectUnauthorized]);
         const stderr = output.stderr.toString();
         const stdout = output.stdout.toString();
         expect(stderr).toEqual("");

--- a/__tests__/__system__/cli/install/program/__scripts__/install_program_fully_qualified.sh
+++ b/__tests__/__system__/cli/install/program/__scripts__/install_program_fully_qualified.sh
@@ -8,5 +8,6 @@ HOST=$4
 PORT=$5
 USER=$6
 PASSWORD=$7
-
-zowe cics install program "$program_name" "$csd_group" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD
+PROTOCOL=$8
+REJECT=$9
+zowe cics install program "$program_name" "$csd_group" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"

--- a/__tests__/__system__/cli/install/program/__snapshots__/cli.install.program.system.test.ts.snap
+++ b/__tests__/__system__/cli/install/program/__snapshots__/cli.install.program.system.test.ts.snap
@@ -62,6 +62,19 @@ exports[`CICS install program command should be able to display the help 1`] = `
 
       Mainframe (CICS) password, which can be the same as your TSO password.
 
+   --reject-unauthorized  | --ru (boolean)
+
+      Reject self-signed certificates.
+
+      Default value: true
+
+   --protocol  | -o (string)
+
+      Specifies CMCI protocol (http or https).
+
+      Default value: http
+      Allowed values: http, https
+
  PROFILE OPTIONS
  ---------------
 

--- a/__tests__/__system__/cli/install/program/cli.install.program.system.test.ts
+++ b/__tests__/__system__/cli/install/program/cli.install.program.system.test.ts
@@ -22,6 +22,8 @@ let host: string;
 let port: number;
 let user: string;
 let password: string;
+let protocol: string;
+let rejectUnauthorized: boolean;
 
 describe("CICS install program command", () => {
 
@@ -37,6 +39,8 @@ describe("CICS install program command", () => {
         port = TEST_ENVIRONMENT.systemTestProperties.cmci.port;
         user = TEST_ENVIRONMENT.systemTestProperties.cmci.user;
         password = TEST_ENVIRONMENT.systemTestProperties.cmci.password;
+        protocol = TEST_ENVIRONMENT.systemTestProperties.cmci.protocol;
+        rejectUnauthorized = TEST_ENVIRONMENT.systemTestProperties.cmci.rejectUnauthorized;
     });
 
     afterAll(async () => {
@@ -52,7 +56,7 @@ describe("CICS install program command", () => {
             user: cmciProperties.user,
             password: cmciProperties.password,
             strictSSL: false,
-            protocol: "http",
+            protocol: protocol as any || "http",
         });
 
         return CicsCmciRestClient.deleteExpectParsedXml(session,
@@ -69,7 +73,7 @@ describe("CICS install program command", () => {
             user: cmciProperties.user,
             password: cmciProperties.password,
             strictSSL: false,
-            protocol: "http",
+            protocol: protocol as any || "http",
         });
 
         return CicsCmciRestClient.deleteExpectParsedXml(deleteSession,
@@ -134,7 +138,9 @@ describe("CICS install program command", () => {
                 host,
                 port,
                 user,
-                password]);
+                password,
+                protocol,
+                rejectUnauthorized]);
         let stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
@@ -147,7 +153,9 @@ describe("CICS install program command", () => {
                 host,
                 port,
                 user,
-                password]);
+                password,
+                protocol,
+                rejectUnauthorized]);
         stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);

--- a/__tests__/__system__/cli/install/transaction/__scripts__/install_transaction_fully_qualified.sh
+++ b/__tests__/__system__/cli/install/transaction/__scripts__/install_transaction_fully_qualified.sh
@@ -8,5 +8,6 @@ HOST=$4
 PORT=$5
 USER=$6
 PASSWORD=$7
-
-zowe cics install transaction "$transaction_name" "$csd_group" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD
+PROTOCOL=$8
+REJECT=$9
+zowe cics install transaction "$transaction_name" "$csd_group" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol $PROTOCOL --reject-unauthorized $REJECT

--- a/__tests__/__system__/cli/install/transaction/__snapshots__/cli.install.transaction.system.test.ts.snap
+++ b/__tests__/__system__/cli/install/transaction/__snapshots__/cli.install.transaction.system.test.ts.snap
@@ -62,6 +62,19 @@ exports[`CICS install transaction command should be able to display the help 1`]
 
       Mainframe (CICS) password, which can be the same as your TSO password.
 
+   --reject-unauthorized  | --ru (boolean)
+
+      Reject self-signed certificates.
+
+      Default value: true
+
+   --protocol  | -o (string)
+
+      Specifies CMCI protocol (http or https).
+
+      Default value: http
+      Allowed values: http, https
+
  PROFILE OPTIONS
  ---------------
 

--- a/__tests__/__system__/cli/install/transaction/cli.install.transaction.system.test.ts
+++ b/__tests__/__system__/cli/install/transaction/cli.install.transaction.system.test.ts
@@ -22,6 +22,8 @@ let host: string;
 let port: number;
 let user: string;
 let password: string;
+let protocol: string;
+let rejectUnauthorized: boolean;
 
 describe("CICS install transaction command", () => {
 
@@ -37,6 +39,8 @@ describe("CICS install transaction command", () => {
         port = TEST_ENVIRONMENT.systemTestProperties.cmci.port;
         user = TEST_ENVIRONMENT.systemTestProperties.cmci.user;
         password = TEST_ENVIRONMENT.systemTestProperties.cmci.password;
+        protocol = TEST_ENVIRONMENT.systemTestProperties.cmci.protocol;
+        rejectUnauthorized = TEST_ENVIRONMENT.systemTestProperties.cmci.rejectUnauthorized;
     });
 
     afterAll(async () => {
@@ -135,7 +139,9 @@ describe("CICS install transaction command", () => {
                 host,
                 port,
                 user,
-                password]);
+                password,
+                protocol,
+                rejectUnauthorized]);
         let stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
@@ -148,7 +154,9 @@ describe("CICS install transaction command", () => {
                 host,
                 port,
                 user,
-                password]);
+                password,
+                protocol,
+                rejectUnauthorized]);
         stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);

--- a/__tests__/__system__/cli/profiles/__snapshots__/cli.profile.create.cics-profile.integration.test.ts.snap
+++ b/__tests__/__system__/cli/profiles/__snapshots__/cli.profile.create.cics-profile.integration.test.ts.snap
@@ -65,6 +65,22 @@ exports[`Create cics Profile Success scenarios should display create cics profil
 
       Overwrite the cics profile when a profile of the same name exists.
 
+ CICS CONNECTION OPTIONS
+ -----------------------
+
+   --reject-unauthorized  | --ru (boolean)
+
+      Reject self-signed certificates.
+
+      Default value: true
+
+   --protocol  | -o (string)
+
+      Specifies CMCI protocol (http or https).
+
+      Default value: http
+      Allowed values: http, https
+
  GLOBAL OPTIONS
  --------------
 

--- a/__tests__/__system__/cli/refresh/program/__snapshots__/cli.refresh.program.system.test.ts.snap
+++ b/__tests__/__system__/cli/refresh/program/__snapshots__/cli.refresh.program.system.test.ts.snap
@@ -57,6 +57,19 @@ exports[`CICS refresh program command should be able to display the help 1`] = `
 
       Mainframe (CICS) password, which can be the same as your TSO password.
 
+   --reject-unauthorized  | --ru (boolean)
+
+      Reject self-signed certificates.
+
+      Default value: true
+
+   --protocol  | -o (string)
+
+      Specifies CMCI protocol (http or https).
+
+      Default value: http
+      Allowed values: http, https
+
  PROFILE OPTIONS
  ---------------
 

--- a/__tests__/cli/define/__snapshots__/Define.definition.unit.test.ts.snap
+++ b/__tests__/cli/define/__snapshots__/Define.definition.unit.test.ts.snap
@@ -57,6 +57,35 @@ Object {
           "required": true,
           "type": "string",
         },
+        Object {
+          "aliases": Array [
+            "ru",
+          ],
+          "defaultValue": true,
+          "description": "Reject self-signed certificates.",
+          "group": "Cics Connection Options",
+          "name": "reject-unauthorized",
+          "required": false,
+          "type": "boolean",
+        },
+        Object {
+          "aliases": Array [
+            "o",
+          ],
+          "allowableValues": Object {
+            "caseSensitive": false,
+            "values": Array [
+              "http",
+              "https",
+            ],
+          },
+          "defaultValue": "http",
+          "description": "Specifies CMCI protocol (http or https).",
+          "group": "Cics Connection Options",
+          "name": "protocol",
+          "required": true,
+          "type": "string",
+        },
       ],
     },
   ],

--- a/__tests__/cli/define/program/Program.handler.unit.test.ts
+++ b/__tests__/cli/define/program/Program.handler.unit.test.ts
@@ -9,7 +9,7 @@
 *                                                                                 *
 */
 
-import { IHandlerParameters, IProfile, CommandProfiles, Session } from "@brightside/imperative";
+import { CommandProfiles, IHandlerParameters, IProfile, Session } from "@brightside/imperative";
 import { ICMCIApiResponse } from "../../../../src";
 import { ProgramDefinition } from "../../../../src/cli/define/program/Program.definition";
 import ProgramHandler from "../../../../src/cli/define/program/Program.handler";
@@ -21,6 +21,8 @@ const host = "somewhere.com";
 const port = "43443";
 const user = "someone";
 const password = "somesecret";
+const protocol = "http";
+const rejectUnauthorized = false;
 
 const PROFILE_MAP = new Map<string, IProfile[]>();
 PROFILE_MAP.set(
@@ -100,7 +102,9 @@ describe("DefineProgramHandler", () => {
             host,
             port,
             user,
-            password
+            password,
+            rejectUnauthorized,
+            protocol
         };
 
         await handler.process(commandParameters);
@@ -114,8 +118,8 @@ describe("DefineProgramHandler", () => {
                 port: testProfile.port,
                 user: testProfile.user,
                 password: testProfile.password,
-                strictSSL: false,
-                protocol: "http",
+                rejectUnauthorized,
+                protocol
             }),
             {
                 name: programName,

--- a/__tests__/cli/define/transaction/Transaction.handler.unit.test.ts
+++ b/__tests__/cli/define/transaction/Transaction.handler.unit.test.ts
@@ -9,7 +9,7 @@
 *                                                                                 *
 */
 
-import { IHandlerParameters, IProfile, CommandProfiles, Session } from "@brightside/imperative";
+import { CommandProfiles, IHandlerParameters, IProfile, Session } from "@brightside/imperative";
 import { ICMCIApiResponse } from "../../../../src";
 import { TransactionDefinition } from "../../../../src/cli/define/transaction/Transaction.definition";
 import TransactionHandler from "../../../../src/cli/define/transaction/Transaction.handler";
@@ -21,6 +21,8 @@ const host = "somewhere.com";
 const port = "43443";
 const user = "someone";
 const password = "somesecret";
+const protocol = "http";
+const rejectUnauthorized = false;
 
 const PROFILE_MAP = new Map<string, IProfile[]>();
 PROFILE_MAP.set(
@@ -102,7 +104,9 @@ describe("DefineTransactionHandler", () => {
             host,
             port,
             user,
-            password
+            password,
+            rejectUnauthorized,
+            protocol
         };
 
         await handler.process(commandParameters);
@@ -116,8 +120,8 @@ describe("DefineTransactionHandler", () => {
                 port: testProfile.port,
                 user: testProfile.user,
                 password: testProfile.password,
-                strictSSL: false,
-                protocol: "http",
+                rejectUnauthorized,
+                protocol
             }),
             {
                 name: transactionName,

--- a/__tests__/cli/delete/__snapshots__/Delete.definition.unit.test.ts.snap
+++ b/__tests__/cli/delete/__snapshots__/Delete.definition.unit.test.ts.snap
@@ -57,6 +57,35 @@ Object {
           "required": true,
           "type": "string",
         },
+        Object {
+          "aliases": Array [
+            "ru",
+          ],
+          "defaultValue": true,
+          "description": "Reject self-signed certificates.",
+          "group": "Cics Connection Options",
+          "name": "reject-unauthorized",
+          "required": false,
+          "type": "boolean",
+        },
+        Object {
+          "aliases": Array [
+            "o",
+          ],
+          "allowableValues": Object {
+            "caseSensitive": false,
+            "values": Array [
+              "http",
+              "https",
+            ],
+          },
+          "defaultValue": "http",
+          "description": "Specifies CMCI protocol (http or https).",
+          "group": "Cics Connection Options",
+          "name": "protocol",
+          "required": true,
+          "type": "string",
+        },
       ],
     },
   ],

--- a/__tests__/cli/delete/program/Program.handler.unit.test.ts
+++ b/__tests__/cli/delete/program/Program.handler.unit.test.ts
@@ -9,7 +9,7 @@
 *                                                                                 *
 */
 
-import { IHandlerParameters, IProfile, CommandProfiles, Session } from "@brightside/imperative";
+import { CommandProfiles, IHandlerParameters, IProfile, Session } from "@brightside/imperative";
 import { ICMCIApiResponse } from "../../../../src";
 import { ProgramDefinition } from "../../../../src/cli/delete/program/Program.definition";
 import ProgramHandler from "../../../../src/cli/delete/program/Program.handler";
@@ -21,6 +21,8 @@ const host = "somewhere.com";
 const port = "43443";
 const user = "someone";
 const password = "somesecret";
+const protocol = "http";
+const rejectUnauthorized = false;
 
 const PROFILE_MAP = new Map<string, IProfile[]>();
 PROFILE_MAP.set(
@@ -100,7 +102,9 @@ describe("DiscardProgramHandler", () => {
             host,
             port,
             user,
-            password
+            password,
+            rejectUnauthorized,
+            protocol
         };
 
         await handler.process(commandParameters);
@@ -113,8 +117,8 @@ describe("DiscardProgramHandler", () => {
                 port: testProfile.port,
                 user: testProfile.user,
                 password: testProfile.password,
-                strictSSL: false,
-                protocol: "http",
+                rejectUnauthorized,
+                protocol
             }),
             {
                 name: programName,

--- a/__tests__/cli/delete/transaction/Transaction.handler.unit.test.ts
+++ b/__tests__/cli/delete/transaction/Transaction.handler.unit.test.ts
@@ -9,7 +9,7 @@
 *                                                                                 *
 */
 
-import { IHandlerParameters, IProfile, CommandProfiles, Session } from "@brightside/imperative";
+import { CommandProfiles, IHandlerParameters, IProfile, Session } from "@brightside/imperative";
 import { ICMCIApiResponse } from "../../../../src";
 import { TransactionDefinition } from "../../../../src/cli/delete/transaction/Transaction.definition";
 import TransactionHandler from "../../../../src/cli/delete/transaction/Transaction.handler";
@@ -21,6 +21,8 @@ const host = "somewhere.com";
 const port = "43443";
 const user = "someone";
 const password = "somesecret";
+const protocol = "http";
+const rejectUnauthorized = false;
 
 const PROFILE_MAP = new Map<string, IProfile[]>();
 PROFILE_MAP.set(
@@ -100,7 +102,9 @@ describe("DiscardTransactionHandler", () => {
             host,
             port,
             user,
-            password
+            password,
+            protocol,
+            rejectUnauthorized
         };
 
         await handler.process(commandParameters);
@@ -114,8 +118,8 @@ describe("DiscardTransactionHandler", () => {
                 port: testProfile.port,
                 user: testProfile.user,
                 password: testProfile.password,
-                strictSSL: false,
-                protocol: "http",
+                rejectUnauthorized,
+                protocol
             }),
             {
                 name: transactionName,

--- a/__tests__/cli/discard/__snapshots__/Discard.definition.unit.test.ts.snap
+++ b/__tests__/cli/discard/__snapshots__/Discard.definition.unit.test.ts.snap
@@ -57,6 +57,35 @@ Object {
           "required": true,
           "type": "string",
         },
+        Object {
+          "aliases": Array [
+            "ru",
+          ],
+          "defaultValue": true,
+          "description": "Reject self-signed certificates.",
+          "group": "Cics Connection Options",
+          "name": "reject-unauthorized",
+          "required": false,
+          "type": "boolean",
+        },
+        Object {
+          "aliases": Array [
+            "o",
+          ],
+          "allowableValues": Object {
+            "caseSensitive": false,
+            "values": Array [
+              "http",
+              "https",
+            ],
+          },
+          "defaultValue": "http",
+          "description": "Specifies CMCI protocol (http or https).",
+          "group": "Cics Connection Options",
+          "name": "protocol",
+          "required": true,
+          "type": "string",
+        },
       ],
     },
   ],

--- a/__tests__/cli/discard/program/Program.handler.unit.test.ts
+++ b/__tests__/cli/discard/program/Program.handler.unit.test.ts
@@ -9,7 +9,7 @@
 *                                                                                 *
 */
 
-import { IHandlerParameters, IProfile, CommandProfiles, Session } from "@brightside/imperative";
+import { CommandProfiles, IHandlerParameters, IProfile, Session } from "@brightside/imperative";
 import { ICMCIApiResponse } from "../../../../src";
 import { ProgramDefinition } from "../../../../src/cli/discard/program/Program.definition";
 import ProgramHandler from "../../../../src/cli/discard/program/Program.handler";
@@ -21,6 +21,8 @@ const host = "somewhere.com";
 const port = "43443";
 const user = "someone";
 const password = "somesecret";
+const protocol = "http";
+const rejectUnauthorized = false;
 
 const PROFILE_MAP = new Map<string, IProfile[]>();
 PROFILE_MAP.set(
@@ -100,7 +102,9 @@ describe("DiscardProgramHandler", () => {
             host,
             port,
             user,
-            password
+            password,
+            protocol,
+            rejectUnauthorized
         };
 
         await handler.process(commandParameters);
@@ -114,8 +118,8 @@ describe("DiscardProgramHandler", () => {
                 port: testProfile.port,
                 user: testProfile.user,
                 password: testProfile.password,
-                strictSSL: false,
-                protocol: "http",
+                rejectUnauthorized,
+                protocol
             }),
             {
                 name: programName,

--- a/__tests__/cli/discard/transaction/Transaction.handler.unit.test.ts
+++ b/__tests__/cli/discard/transaction/Transaction.handler.unit.test.ts
@@ -9,7 +9,7 @@
 *                                                                                 *
 */
 
-import { IHandlerParameters, IProfile, CommandProfiles, Session } from "@brightside/imperative";
+import { CommandProfiles, IHandlerParameters, IProfile, Session } from "@brightside/imperative";
 import { ICMCIApiResponse } from "../../../../src";
 import { TransactionDefinition } from "../../../../src/cli/discard/transaction/Transaction.definition";
 import TransactionHandler from "../../../../src/cli/discard/transaction/Transaction.handler";
@@ -21,6 +21,8 @@ const host = "somewhere.com";
 const port = "43443";
 const user = "someone";
 const password = "somesecret";
+const protocol = "http";
+const rejectUnauthorized = false;
 
 const PROFILE_MAP = new Map<string, IProfile[]>();
 PROFILE_MAP.set(
@@ -100,7 +102,9 @@ describe("DiscardTransactionHandler", () => {
             host,
             port,
             user,
-            password
+            password,
+            protocol,
+            rejectUnauthorized
         };
 
         await handler.process(commandParameters);
@@ -114,8 +118,8 @@ describe("DiscardTransactionHandler", () => {
                 port: testProfile.port,
                 user: testProfile.user,
                 password: testProfile.password,
-                strictSSL: false,
-                protocol: "http",
+                protocol,
+                rejectUnauthorized
             }),
             {
                 name: transactionName,

--- a/__tests__/cli/get/__snapshots__/Get.definition.unit.test.ts.snap
+++ b/__tests__/cli/get/__snapshots__/Get.definition.unit.test.ts.snap
@@ -54,6 +54,35 @@ Object {
           "required": true,
           "type": "string",
         },
+        Object {
+          "aliases": Array [
+            "ru",
+          ],
+          "defaultValue": true,
+          "description": "Reject self-signed certificates.",
+          "group": "Cics Connection Options",
+          "name": "reject-unauthorized",
+          "required": false,
+          "type": "boolean",
+        },
+        Object {
+          "aliases": Array [
+            "o",
+          ],
+          "allowableValues": Object {
+            "caseSensitive": false,
+            "values": Array [
+              "http",
+              "https",
+            ],
+          },
+          "defaultValue": "http",
+          "description": "Specifies CMCI protocol (http or https).",
+          "group": "Cics Connection Options",
+          "name": "protocol",
+          "required": true,
+          "type": "string",
+        },
       ],
     },
   ],

--- a/__tests__/cli/get/resource/Resource.handler.unit.test.ts
+++ b/__tests__/cli/get/resource/Resource.handler.unit.test.ts
@@ -9,7 +9,7 @@
 *                                                                                 *
 */
 
-import { IHandlerParameters, IProfile, CommandProfiles, Session } from "@brightside/imperative";
+import { CommandProfiles, IHandlerParameters, IProfile, Session } from "@brightside/imperative";
 import { ICMCIApiResponse } from "../../../../src";
 import { ResourceDefinition } from "../../../../src/cli/get/resource/Resource.definition";
 import ResourceHandler from "../../../../src/cli/get/resource/Resource.handler";
@@ -21,6 +21,8 @@ const host = "somewhere.com";
 const port = "43443";
 const user = "someone";
 const password = "somesecret";
+const protocol = "http";
+const rejectUnauthorized = false;
 
 const PROFILE_MAP = new Map<string, IProfile[]>();
 PROFILE_MAP.set(
@@ -84,7 +86,7 @@ describe("GetResourceHandler", () => {
 
     beforeEach(() => {
         functionSpy.mockClear();
-        defaultReturn.response.records[resourceName.toLowerCase()] = [{prop:"test1"}, {prop:"test2"}];
+        defaultReturn.response.records[resourceName.toLowerCase()] = [{prop: "test1"}, {prop: "test2"}];
         functionSpy.mockImplementation(async () => defaultReturn);
     });
 
@@ -99,7 +101,9 @@ describe("GetResourceHandler", () => {
             host,
             port,
             user,
-            password
+            password,
+            protocol,
+            rejectUnauthorized
         };
 
         await handler.process(commandParameters);
@@ -113,8 +117,8 @@ describe("GetResourceHandler", () => {
                 port: testProfile.port,
                 user: testProfile.user,
                 password: testProfile.password,
-                strictSSL: false,
-                protocol: "http",
+                rejectUnauthorized,
+                protocol
             }),
             {
                 name: resourceName,

--- a/__tests__/cli/install/__snapshots__/Install.definition.unit.test.ts.snap
+++ b/__tests__/cli/install/__snapshots__/Install.definition.unit.test.ts.snap
@@ -57,6 +57,35 @@ Object {
           "required": true,
           "type": "string",
         },
+        Object {
+          "aliases": Array [
+            "ru",
+          ],
+          "defaultValue": true,
+          "description": "Reject self-signed certificates.",
+          "group": "Cics Connection Options",
+          "name": "reject-unauthorized",
+          "required": false,
+          "type": "boolean",
+        },
+        Object {
+          "aliases": Array [
+            "o",
+          ],
+          "allowableValues": Object {
+            "caseSensitive": false,
+            "values": Array [
+              "http",
+              "https",
+            ],
+          },
+          "defaultValue": "http",
+          "description": "Specifies CMCI protocol (http or https).",
+          "group": "Cics Connection Options",
+          "name": "protocol",
+          "required": true,
+          "type": "string",
+        },
       ],
     },
   ],

--- a/__tests__/cli/install/program/Program.handler.unit.test.ts
+++ b/__tests__/cli/install/program/Program.handler.unit.test.ts
@@ -9,7 +9,7 @@
 *                                                                                 *
 */
 
-import { IHandlerParameters, IProfile, CommandProfiles, Session } from "@brightside/imperative";
+import { CommandProfiles, IHandlerParameters, IProfile, Session } from "@brightside/imperative";
 import { ICMCIApiResponse } from "../../../../src";
 import { ProgramDefinition } from "../../../../src/cli/install/program/Program.definition";
 import ProgramHandler from "../../../../src/cli/install/program/Program.handler";
@@ -21,6 +21,8 @@ const host = "somewhere.com";
 const port = "43443";
 const user = "someone";
 const password = "somesecret";
+const protocol = "http";
+const rejectUnauthorized = false;
 
 const PROFILE_MAP = new Map<string, IProfile[]>();
 PROFILE_MAP.set(
@@ -100,7 +102,9 @@ describe("InstallProgramHandler", () => {
             host,
             port,
             user,
-            password
+            password,
+            protocol,
+            rejectUnauthorized
         };
 
         await handler.process(commandParameters);
@@ -114,8 +118,8 @@ describe("InstallProgramHandler", () => {
                 port: testProfile.port,
                 user: testProfile.user,
                 password: testProfile.password,
-                strictSSL: false,
-                protocol: "http",
+                rejectUnauthorized,
+                protocol
             }),
             {
                 name: programName,

--- a/__tests__/cli/install/transaction/Transaction.handler.unit.test.ts
+++ b/__tests__/cli/install/transaction/Transaction.handler.unit.test.ts
@@ -9,7 +9,7 @@
 *                                                                                 *
 */
 
-import { IHandlerParameters, IProfile, CommandProfiles, Session } from "@brightside/imperative";
+import { CommandProfiles, IHandlerParameters, IProfile, Session } from "@brightside/imperative";
 import { ICMCIApiResponse } from "../../../../src";
 import { TransactionDefinition } from "../../../../src/cli/install/transaction/Transaction.definition";
 import TransactionHandler from "../../../../src/cli/install/transaction/Transaction.handler";
@@ -21,107 +21,110 @@ const host = "somewhere.com";
 const port = "43443";
 const user = "someone";
 const password = "somesecret";
+const rejectUnauthorized = false;
+const protocol = "http";
 
 const PROFILE_MAP = new Map<string, IProfile[]>();
 PROFILE_MAP.set(
-    "cics", [{
-        name: "cics",
-        type: "cics",
-        host,
-        port,
-        user,
-        password
-    }]
+  "cics", [{
+    name: "cics",
+    type: "cics",
+    host,
+    port,
+    user,
+    password
+  }]
 );
 const PROFILES: CommandProfiles = new CommandProfiles(PROFILE_MAP);
 const DEFAULT_PARAMETERS: IHandlerParameters = {
-    arguments: {$0: "", _: []}, // Please provide arguments later on
-    response: {
-        data: {
-            setMessage: jest.fn((setMsgArgs) => {
-                expect(setMsgArgs).toMatchSnapshot();
-            }),
-            setObj: jest.fn((setObjArgs) => {
-                expect(setObjArgs).toMatchSnapshot();
-            })
-        },
-        console: {
-            log: jest.fn((logs) => {
-                expect(logs.toString()).toMatchSnapshot();
-            }),
-            error: jest.fn((errors) => {
-                expect(errors.toString()).toMatchSnapshot();
-            }),
-            errorHeader: jest.fn(() => undefined)
-        },
-        progress: {
-            startBar: jest.fn((parms) => undefined),
-            endBar: jest.fn(() => undefined)
-        },
-        format: {
-            output: jest.fn((parms) => {
-                expect(parms).toMatchSnapshot();
-            })
-        }
+  arguments: {$0: "", _: []}, // Please provide arguments later on
+  response: {
+    data: {
+      setMessage: jest.fn((setMsgArgs) => {
+        expect(setMsgArgs).toMatchSnapshot();
+      }),
+      setObj: jest.fn((setObjArgs) => {
+        expect(setObjArgs).toMatchSnapshot();
+      })
     },
-    definition: TransactionDefinition,
-    fullDefinition: TransactionDefinition,
-    profiles: PROFILES
+    console: {
+      log: jest.fn((logs) => {
+        expect(logs.toString()).toMatchSnapshot();
+      }),
+      error: jest.fn((errors) => {
+        expect(errors.toString()).toMatchSnapshot();
+      }),
+      errorHeader: jest.fn(() => undefined)
+    },
+    progress: {
+      startBar: jest.fn((parms) => undefined),
+      endBar: jest.fn(() => undefined)
+    },
+    format: {
+      output: jest.fn((parms) => {
+        expect(parms).toMatchSnapshot();
+      })
+    }
+  },
+  definition: TransactionDefinition,
+  fullDefinition: TransactionDefinition,
+  profiles: PROFILES
 };
 
 describe("InstallTransactionHandler", () => {
-    const transactionName = "testTransaction";
-    const regionName = "testRegion";
-    const csdGroup = "testGroup";
+  const transactionName = "testTransaction";
+  const regionName = "testRegion";
+  const csdGroup = "testGroup";
 
-    const defaultReturn: ICMCIApiResponse = {
-        response: {
-            resultsummary: {api_response1: "1024", api_response2: "0", recordcount: "0", displayed_recordcount: "0"},
-            records: "testing"
-        }
+  const defaultReturn: ICMCIApiResponse = {
+    response: {
+      resultsummary: {api_response1: "1024", api_response2: "0", recordcount: "0", displayed_recordcount: "0"},
+      records: "testing"
+    }
+  };
+
+  const functionSpy = jest.spyOn(Install, "installTransaction");
+
+  beforeEach(() => {
+    functionSpy.mockClear();
+    functionSpy.mockImplementation(async () => defaultReturn);
+  });
+
+  it("should call the installTransaction api", async () => {
+    const handler = new TransactionHandler();
+
+    const commandParameters = {...DEFAULT_PARAMETERS};
+    commandParameters.arguments = {
+      ...commandParameters.arguments,
+      transactionName,
+      regionName,
+      csdGroup,
+      host,
+      port,
+      user,
+      password,
+      rejectUnauthorized
     };
 
-    const functionSpy = jest.spyOn(Install, "installTransaction");
+    await handler.process(commandParameters);
 
-    beforeEach(() => {
-        functionSpy.mockClear();
-        functionSpy.mockImplementation(async () => defaultReturn);
-    });
-
-    it("should call the installTransaction api", async () => {
-        const handler = new TransactionHandler();
-
-        const commandParameters = {...DEFAULT_PARAMETERS};
-        commandParameters.arguments = {
-            ...commandParameters.arguments,
-            transactionName,
-            regionName,
-            csdGroup,
-            host,
-            port,
-            user,
-            password
-        };
-
-        await handler.process(commandParameters);
-
-        expect(functionSpy).toHaveBeenCalledTimes(1);
-        const testProfile = PROFILE_MAP.get("cics")[0];
-        expect(functionSpy).toHaveBeenCalledWith(
-            new Session({
-                type: "basic",
-                hostname: testProfile.host,
-                port: testProfile.port,
-                user: testProfile.user,
-                password: testProfile.password,
-                strictSSL: false,
-                protocol: "http",
-            }),
-            {
-                name: transactionName,
-                csdGroup,
-                regionName
-            }
-        );
-    });
+    expect(functionSpy).toHaveBeenCalledTimes(1);
+    const testProfile = PROFILE_MAP.get("cics")[0];
+    expect(functionSpy).toHaveBeenCalledWith(
+      new Session({
+        type: "basic",
+        hostname: testProfile.host,
+        port: testProfile.port,
+        user: testProfile.user,
+        password: testProfile.password,
+        rejectUnauthorized,
+        protocol
+      }),
+      {
+        name: transactionName,
+        csdGroup,
+        regionName
+      }
+    );
+  });
 });

--- a/__tests__/cli/refresh/__snapshots__/Refresh.definition.unit.test.ts.snap
+++ b/__tests__/cli/refresh/__snapshots__/Refresh.definition.unit.test.ts.snap
@@ -57,6 +57,35 @@ Object {
           "required": true,
           "type": "string",
         },
+        Object {
+          "aliases": Array [
+            "ru",
+          ],
+          "defaultValue": true,
+          "description": "Reject self-signed certificates.",
+          "group": "Cics Connection Options",
+          "name": "reject-unauthorized",
+          "required": false,
+          "type": "boolean",
+        },
+        Object {
+          "aliases": Array [
+            "o",
+          ],
+          "allowableValues": Object {
+            "caseSensitive": false,
+            "values": Array [
+              "http",
+              "https",
+            ],
+          },
+          "defaultValue": "http",
+          "description": "Specifies CMCI protocol (http or https).",
+          "group": "Cics Connection Options",
+          "name": "protocol",
+          "required": true,
+          "type": "string",
+        },
       ],
     },
   ],

--- a/__tests__/cli/refresh/program/Program.handler.unit.test.ts
+++ b/__tests__/cli/refresh/program/Program.handler.unit.test.ts
@@ -9,7 +9,7 @@
 *                                                                                 *
 */
 
-import { IHandlerParameters, IProfile, CommandProfiles, Session } from "@brightside/imperative";
+import { CommandProfiles, IHandlerParameters, IProfile, Session } from "@brightside/imperative";
 import { ICMCIApiResponse } from "../../../../src";
 import { ProgramDefinition } from "../../../../src/cli/refresh/program/Program.definition";
 import ProgramHandler from "../../../../src/cli/refresh/program/Program.handler";
@@ -21,6 +21,7 @@ const host = "somewhere.com";
 const port = "43443";
 const user = "someone";
 const password = "somesecret";
+const protocol = "http";
 
 const PROFILE_MAP = new Map<string, IProfile[]>();
 PROFILE_MAP.set(
@@ -30,7 +31,9 @@ PROFILE_MAP.set(
         host,
         port,
         user,
-        password
+        password,
+        protocol,
+        rejectUnauthorized: false
     }]
 );
 const PROFILES: CommandProfiles = new CommandProfiles(PROFILE_MAP);
@@ -100,7 +103,8 @@ describe("RefreshProgramHandler", () => {
             host,
             port,
             user,
-            password
+            password,
+            rejectUnauthorized: false
         };
 
         await handler.process(commandParameters);
@@ -114,7 +118,7 @@ describe("RefreshProgramHandler", () => {
                 port: testProfile.port,
                 user: testProfile.user,
                 password: testProfile.password,
-                strictSSL: false,
+                rejectUnauthorized: false,
                 protocol: "http",
             }),
             {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightside/cics",
-  "version": "1.0.0-alpha.201902071834",
+  "version": "1.1.0-alpha.201902071834",
   "description": "CLI Plug-in for IBM CICS",
   "repository": {
     "type": "git",
@@ -64,7 +64,7 @@
     "ts-node": "^3.2.0",
     "tslint": "^5.0.0",
     "typedoc": "^0.9.0",
-    "typescript": "^2.3.0",
+    "typescript": "3.2.2",
     "uuid": "^3.2.1"
   },
   "jest": {

--- a/src/cli/CicsSession.ts
+++ b/src/cli/CicsSession.ts
@@ -66,6 +66,31 @@ export class CicsSession {
         group: CicsSession.CICS_CONNECTION_OPTION_GROUP,
         required: true
     };
+    /**
+     * Option used in profile creation and commands for rejectUnauthorized setting for connecting to FMP
+     */
+    public static CICS_OPTION_REJECT_UNAUTHORIZED: ICommandOptionDefinition = {
+        name: "reject-unauthorized",
+        aliases: ["ru"],
+        description: "Reject self-signed certificates.",
+        type: "boolean",
+        defaultValue: true,
+        required: false,
+        group: CicsSession.CICS_CONNECTION_OPTION_GROUP
+    };
+    /**
+     * Option used in profile creation and commands for protocol for CMCI
+     */
+    public static CICS_OPTION_PROTOCOL: ICommandOptionDefinition = {
+        name: "protocol",
+        aliases: ["o"],
+        description: "Specifies CMCI protocol (http or https).",
+        type: "string",
+        defaultValue: "http",
+        required: true,
+        allowableValues: {values: ["http", "https"], caseSensitive: false},
+        group: CicsSession.CICS_CONNECTION_OPTION_GROUP
+    };
 
     /**
      * Options related to connecting to CICS
@@ -75,7 +100,9 @@ export class CicsSession {
         CicsSession.CICS_OPTION_HOST,
         CicsSession.CICS_OPTION_PORT,
         CicsSession.CICS_OPTION_USER,
-        CicsSession.CICS_OPTION_PASSWORD
+        CicsSession.CICS_OPTION_PASSWORD,
+        CicsSession.CICS_OPTION_REJECT_UNAUTHORIZED,
+        CicsSession.CICS_OPTION_PROTOCOL
     ];
 
     /**
@@ -93,7 +120,7 @@ export class CicsSession {
             user: profile.user,
             password: profile.pass,
             basePath: profile.basePath,
-            protocol: "http",
+            protocol: profile.protocol || "http",
         });
     }
 
@@ -112,8 +139,8 @@ export class CicsSession {
             user: args.user,
             password: args.password,
             basePath: args.basePath,
-            strictSSL: false,
-            protocol: "http",
+            rejectUnauthorized: args.rejectUnauthorized,
+            protocol: args.protocol || "http",
         });
     }
 

--- a/src/imperative.ts
+++ b/src/imperative.ts
@@ -12,6 +12,7 @@
 // Imperative version of Zowe CLI
 import { IImperativeConfig } from "@brightside/imperative";
 import { PluginConstants } from "./api/constants/PluginConstants";
+import { CicsSession } from "./cli/CicsSession";
 
 const config: IImperativeConfig = {
     commandModuleGlobs: ["**/cli/*/*.definition!(.d).*s"],
@@ -88,6 +89,14 @@ const config: IImperativeConfig = {
                             description: "The name of the CICSPlex to interact with",
                             type: "string"
                         },
+                    },
+                    rejectUnauthorized: {
+                        type: "boolean",
+                        optionDefinition: CicsSession.CICS_OPTION_REJECT_UNAUTHORIZED
+                    },
+                    protocol: {
+                        type: "string",
+                        optionDefinition: CicsSession.CICS_OPTION_PROTOCOL
                     }
                 },
                 required: ["host"],


### PR DESCRIPTION
Attempt at supporting HTTPS (#22 ) in the same manner as other plugins, by providing a `--protocol` option (and `--reject-unauthorized`) on all commands and on the create profiles command.

Update tests
Update snapshots