### PR TITLE
add peer dependencies for version check

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,18 @@
   "name": "@zowe/cics",
   "version": "2.0.0-alpha.201903191436",
   "description": "Zowe CLI Plug-in for IBM CICS",
-  "repository":   {
+  "repository": {
     "type": "git",
     "url": "https://github.com/gizafoundation/zowe-cli-cics-plugin.git"
   },
   "main": "lib/index.js",
-  "files": ["lib"],
-  "publishConfig": {"registry": "https://gizaartifactory.jfrog.io/gizaartifactory/api/npm/npm-local-release/"},
-  "scripts":   {
+  "files": [
+    "lib"
+  ],
+  "publishConfig": {
+    "registry": "https://gizaartifactory.jfrog.io/gizaartifactory/api/npm/npm-local-release/"
+  },
+  "scripts": {
     "build": "node scripts/updateLicense.js && tsc --pretty && npm run checkTestsCompile",
     "checkTestsCompile": "echo \"Checking that test source compiles...\" && tsc --project __tests__/test-tsconfig.json --noEmit ",
     "prebuild": "npm run clean && npm run lint && echo Using TypeScript && tsc --version",
@@ -24,9 +28,17 @@
     "test:unit": "env-cmd __tests__/__resources__/env/unit.env jest --coverage --testPathIgnorePatterns \".*/__system__/.*\" ",
     "installPlugin": "npm install && npm run clean && npm run build && zowe plugins install ."
   },
-  "imperative": {"configurationModule": "lib/imperative.js"},
-  "dependencies": {"xml2js": "0.4.19"},
-  "devDependencies":   {
+  "imperative": {
+    "configurationModule": "lib/imperative.js"
+  },
+  "dependencies": {
+    "xml2js": "0.4.19"
+  },
+  "peerDependencies": {
+    "@zowe/imperative": "^3.0.0",
+    "@zowe/cli": "^3.0.0"
+  },
+  "devDependencies": {
     "@types/jest": "^20.0.5",
     "@types/node": "^8.0.0",
     "@types/xml2js": "^0.4.3",
@@ -52,26 +64,34 @@
     "typescript": "3.2.2",
     "uuid": "^3.2.1"
   },
-  "jest":   {
-    "setupFilesAfterEnv": ["./__tests__/setUpJest.js"],
-    "modulePathIgnorePatterns": ["__tests__/__snapshots__/"],
+  "jest": {
+    "setupFilesAfterEnv": [
+      "./__tests__/setUpJest.js"
+    ],
+    "modulePathIgnorePatterns": [
+      "__tests__/__snapshots__/"
+    ],
     "testResultsProcessor": "jest-stare",
-    "transform": {".(ts)": "ts-jest"},
+    "transform": {
+      ".(ts)": "ts-jest"
+    },
     "testRegex": "(test|spec)\\.ts$",
-    "moduleFileExtensions":     [
+    "moduleFileExtensions": [
       "ts",
       "js"
     ],
-    "testPathIgnorePatterns": ["<rootDir>/__tests__/__results__"],
+    "testPathIgnorePatterns": [
+      "<rootDir>/__tests__/__results__"
+    ],
     "testEnvironment": "node",
-    "collectCoverageFrom":     [
+    "collectCoverageFrom": [
       "src/**/*.ts",
       "!**/__tests__/**",
       "!**/index.ts",
       "!**/main.ts"
     ],
     "collectCoverage": false,
-    "coverageReporters":     [
+    "coverageReporters": [
       "json",
       "lcov",
       "text",
@@ -79,16 +99,18 @@
     ],
     "coverageDirectory": "<rootDir>/__tests__/__results__/unit/coverage"
   },
-  "jest-stare":   {
+  "jest-stare": {
     "resultDir": "__tests__/__results__/jest-stare",
-    "additionalResultsProcessors":     [
+    "additionalResultsProcessors": [
       "jest-junit",
       "jest-html-reporter"
     ],
     "coverageLink": "../coverage/lcov-report/index.html"
   },
-  "jest-junit": {"output": "__tests__/__results__/junit.xml"},
-  "jest-html-reporter":   {
+  "jest-junit": {
+    "output": "__tests__/__results__/junit.xml"
+  },
+  "jest-html-reporter": {
     "pageTitle": "Brightside CICS Plugin Test Results",
     "outputPath": "__tests__/__results__/results.html",
     "includeFailureMsg": true


### PR DESCRIPTION
Left this off when migrating to @zowe namespace