### PR TITLE
Add Define URIMAP CLI and API, Delete URIMAP API

### DIFF
--- a/__tests__/__system__/api/methods/define/Define.urimap-client.system.test.ts
+++ b/__tests__/__system__/api/methods/define/Define.urimap-client.system.test.ts
@@ -1,0 +1,142 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { Session } from "@zowe/imperative";
+import { ITestEnvironment } from "../../../../../__tests__/__src__/environment/doc/response/ITestEnvironment";
+import { TestEnvironment } from "../../../../../__tests__/__src__/environment/TestEnvironment";
+import { generateRandomAlphaNumericString } from "../../../../__src__/TestUtils";
+import { defineUrimapClient, deleteUrimap, IURIMapParms, } from "../../../../../src";
+
+let testEnvironment: ITestEnvironment;
+let regionName: string;
+let csdGroup: string;
+let session: Session;
+
+describe("CICS Define client URImap", () => {
+
+    beforeAll(async () => {
+        testEnvironment = await TestEnvironment.setUp({
+            testName: "cics_cmci_define_urimap-client",
+            installPlugin: true,
+            tempProfileTypes: ["cics"]
+        });
+        csdGroup = testEnvironment.systemTestProperties.cmci.csdGroup;
+        regionName = testEnvironment.systemTestProperties.cmci.regionName;
+        const cmciProperties = await testEnvironment.systemTestProperties.cmci;
+
+        session = new Session({
+            user: cmciProperties.user,
+            password: cmciProperties.password,
+            hostname: cmciProperties.host,
+            port: cmciProperties.port,
+            type: "basic",
+            strictSSL: false,
+            protocol: testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+        });
+    });
+
+    afterAll(async () => {
+        await TestEnvironment.cleanUp(testEnvironment);
+    });
+
+    const options: IURIMapParms = {} as any;
+
+    it("should define a URIMap to CICS", async () => {
+        let error;
+        let response;
+
+        const urimapNameSuffixLength = 3;
+        const urimapName = "X" + generateRandomAlphaNumericString(urimapNameSuffixLength);
+
+        options.name = urimapName;
+        options.path = "fake";
+        options.host = "fake";
+        options.scheme = "http";
+        options.csdGroup = csdGroup;
+        options.regionName = regionName;
+
+        try {
+            response = await defineUrimapClient(session, options);
+        } catch (err) {
+            error = err;
+        }
+
+        expect(error).toBeFalsy();
+        expect(response).toBeTruthy();
+        expect(response.response.resultsummary.api_response1).toBe("1024");
+        await deleteUrimap(session, options);
+    });
+
+    it("should fail to define a URIMap to CICS with invalid CICS region", async () => {
+        let error;
+        let response;
+
+        const urimapNameSuffixLength = 3;
+        const urimapName = "X" + generateRandomAlphaNumericString(urimapNameSuffixLength);
+
+        options.name = urimapName;
+        options.path = "fake";
+        options.host = "fake";
+        options.scheme = "http";
+        options.csdGroup = csdGroup;
+        options.regionName = "FAKE";
+
+        try {
+            response = await defineUrimapClient(session, options);
+        } catch (err) {
+            error = err;
+        }
+
+        expect(error).toBeTruthy();
+        expect(response).toBeFalsy();
+        expect(error.message).toContain("Did not receive the expected response from CMCI REST API");
+        expect(error.message).toContain("INVALIDPARM");
+    });
+
+    it("should fail to define a URIMap to CICS due to duplicate name", async () => {
+        let error;
+        let response;
+
+        const urimapNameSuffixLength = 3;
+        const urimapName = "X" + generateRandomAlphaNumericString(urimapNameSuffixLength);
+
+        options.name = urimapName;
+        options.path = "fake";
+        options.host = "fake";
+        options.scheme = "http";
+        options.csdGroup = csdGroup;
+        options.regionName = regionName;
+
+        // define a URIMap to CICS
+        try {
+            response = await defineUrimapClient(session, options);
+        } catch (err) {
+            error = err;
+        }
+
+        expect(error).toBeFalsy();
+        expect(response).toBeTruthy();
+        response = null; // reset
+
+        // define the same URIMap and validate duplicate error
+        try {
+            response = await defineUrimapClient(session, options);
+        } catch (err) {
+            error = err;
+        }
+
+        expect(error).toBeTruthy();
+        expect(response).toBeFalsy();
+        expect(error.message).toContain("Did not receive the expected response from CMCI REST API");
+        expect(error.message).toContain("DUPRES");
+        await deleteUrimap(session, options);
+    });
+});

--- a/__tests__/__system__/api/methods/define/Define.urimap-pipeline.system.test.ts
+++ b/__tests__/__system__/api/methods/define/Define.urimap-pipeline.system.test.ts
@@ -1,0 +1,145 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { Session } from "@zowe/imperative";
+import { ITestEnvironment } from "../../../../../__tests__/__src__/environment/doc/response/ITestEnvironment";
+import { TestEnvironment } from "../../../../../__tests__/__src__/environment/TestEnvironment";
+import { generateRandomAlphaNumericString } from "../../../../__src__/TestUtils";
+import { defineUrimapPipeline, deleteUrimap, IURIMapParms, } from "../../../../../src";
+
+let testEnvironment: ITestEnvironment;
+let regionName: string;
+let csdGroup: string;
+let session: Session;
+
+describe("CICS Define pipeline URImap", () => {
+
+    beforeAll(async () => {
+        testEnvironment = await TestEnvironment.setUp({
+            testName: "cics_cmci_define_urimap-pipeline",
+            installPlugin: true,
+            tempProfileTypes: ["cics"]
+        });
+        csdGroup = testEnvironment.systemTestProperties.cmci.csdGroup;
+        regionName = testEnvironment.systemTestProperties.cmci.regionName;
+        const cmciProperties = await testEnvironment.systemTestProperties.cmci;
+
+        session = new Session({
+            user: cmciProperties.user,
+            password: cmciProperties.password,
+            hostname: cmciProperties.host,
+            port: cmciProperties.port,
+            type: "basic",
+            strictSSL: false,
+            protocol: testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+        });
+    });
+
+    afterAll(async () => {
+        await TestEnvironment.cleanUp(testEnvironment);
+    });
+
+    const options: IURIMapParms = {} as any;
+
+    it("should define a URIMap to CICS", async () => {
+        let error;
+        let response;
+
+        const urimapNameSuffixLength = 3;
+        const urimapName = "X" + generateRandomAlphaNumericString(urimapNameSuffixLength);
+
+        options.name = urimapName;
+        options.path = "fake";
+        options.host = "fake";
+        options.scheme = "http";
+        options.pipelineName = "AAAA1234";
+        options.csdGroup = csdGroup;
+        options.regionName = regionName;
+
+        try {
+            response = await defineUrimapPipeline(session, options);
+        } catch (err) {
+            error = err;
+        }
+
+        expect(error).toBeFalsy();
+        expect(response).toBeTruthy();
+        expect(response.response.resultsummary.api_response1).toBe("1024");
+        await deleteUrimap(session, options);
+    });
+
+    it("should fail to define a URIMap to CICS with invalid CICS region", async () => {
+        let error;
+        let response;
+
+        const urimapNameSuffixLength = 3;
+        const urimapName = "X" + generateRandomAlphaNumericString(urimapNameSuffixLength);
+
+        options.name = urimapName;
+        options.path = "fake";
+        options.host = "fake";
+        options.scheme = "http";
+        options.pipelineName = "AAAA1234";
+        options.csdGroup = csdGroup;
+        options.regionName = "FAKE";
+
+        try {
+            response = await defineUrimapPipeline(session, options);
+        } catch (err) {
+            error = err;
+        }
+
+        expect(error).toBeTruthy();
+        expect(response).toBeFalsy();
+        expect(error.message).toContain("Did not receive the expected response from CMCI REST API");
+        expect(error.message).toContain("INVALIDPARM");
+    });
+
+    it("should fail to define a URIMap to CICS due to duplicate name", async () => {
+        let error;
+        let response;
+
+        const urimapNameSuffixLength = 3;
+        const urimapName = "X" + generateRandomAlphaNumericString(urimapNameSuffixLength);
+
+        options.name = urimapName;
+        options.path = "fake";
+        options.host = "fake";
+        options.scheme = "http";
+        options.pipelineName = "AAAA1234";
+        options.csdGroup = csdGroup;
+        options.regionName = regionName;
+
+        // define a URIMap to CICS
+        try {
+            response = await defineUrimapPipeline(session, options);
+        } catch (err) {
+            error = err;
+        }
+
+        expect(error).toBeFalsy();
+        expect(response).toBeTruthy();
+        response = null; // reset
+
+        // define the same URIMap and validate duplicate error
+        try {
+            response = await defineUrimapPipeline(session, options);
+        } catch (err) {
+            error = err;
+        }
+
+        expect(error).toBeTruthy();
+        expect(response).toBeFalsy();
+        expect(error.message).toContain("Did not receive the expected response from CMCI REST API");
+        expect(error.message).toContain("DUPRES");
+        await deleteUrimap(session, options);
+    });
+});

--- a/__tests__/__system__/api/methods/define/Define.urimap-server.system.test.ts
+++ b/__tests__/__system__/api/methods/define/Define.urimap-server.system.test.ts
@@ -1,0 +1,145 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { Session } from "@zowe/imperative";
+import { ITestEnvironment } from "../../../../../__tests__/__src__/environment/doc/response/ITestEnvironment";
+import { TestEnvironment } from "../../../../../__tests__/__src__/environment/TestEnvironment";
+import { generateRandomAlphaNumericString } from "../../../../__src__/TestUtils";
+import { defineUrimapServer, deleteUrimap, IURIMapParms, } from "../../../../../src";
+
+let testEnvironment: ITestEnvironment;
+let regionName: string;
+let csdGroup: string;
+let session: Session;
+
+describe("CICS Define server URImap", () => {
+
+    beforeAll(async () => {
+        testEnvironment = await TestEnvironment.setUp({
+            testName: "cics_cmci_define_urimap-server",
+            installPlugin: true,
+            tempProfileTypes: ["cics"]
+        });
+        csdGroup = testEnvironment.systemTestProperties.cmci.csdGroup;
+        regionName = testEnvironment.systemTestProperties.cmci.regionName;
+        const cmciProperties = await testEnvironment.systemTestProperties.cmci;
+
+        session = new Session({
+            user: cmciProperties.user,
+            password: cmciProperties.password,
+            hostname: cmciProperties.host,
+            port: cmciProperties.port,
+            type: "basic",
+            strictSSL: false,
+            protocol: testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+        });
+    });
+
+    afterAll(async () => {
+        await TestEnvironment.cleanUp(testEnvironment);
+    });
+
+    const options: IURIMapParms = {} as any;
+
+    it("should define a URIMap to CICS", async () => {
+        let error;
+        let response;
+
+        const urimapNameSuffixLength = 3;
+        const urimapName = "X" + generateRandomAlphaNumericString(urimapNameSuffixLength);
+
+        options.name = urimapName;
+        options.path = "fake";
+        options.host = "fake";
+        options.scheme = "http";
+        options.programName = "AAAA1234";
+        options.csdGroup = csdGroup;
+        options.regionName = regionName;
+
+        try {
+            response = await defineUrimapServer(session, options);
+        } catch (err) {
+            error = err;
+        }
+
+        expect(error).toBeFalsy();
+        expect(response).toBeTruthy();
+        expect(response.response.resultsummary.api_response1).toBe("1024");
+        await deleteUrimap(session, options);
+    });
+
+    it("should fail to define a URIMap to CICS with invalid CICS region", async () => {
+        let error;
+        let response;
+
+        const urimapNameSuffixLength = 3;
+        const urimapName = "X" + generateRandomAlphaNumericString(urimapNameSuffixLength);
+
+        options.name = urimapName;
+        options.path = "fake";
+        options.host = "fake";
+        options.scheme = "http";
+        options.programName = "AAAA1234";
+        options.csdGroup = csdGroup;
+        options.regionName = "FAKE";
+
+        try {
+            response = await defineUrimapServer(session, options);
+        } catch (err) {
+            error = err;
+        }
+
+        expect(error).toBeTruthy();
+        expect(response).toBeFalsy();
+        expect(error.message).toContain("Did not receive the expected response from CMCI REST API");
+        expect(error.message).toContain("INVALIDPARM");
+    });
+
+    it("should fail to define a URIMap to CICS due to duplicate name", async () => {
+        let error;
+        let response;
+
+        const urimapNameSuffixLength = 3;
+        const urimapName = "X" + generateRandomAlphaNumericString(urimapNameSuffixLength);
+
+        options.name = urimapName;
+        options.path = "fake";
+        options.host = "fake";
+        options.scheme = "http";
+        options.programName = "AAAA1234";
+        options.csdGroup = csdGroup;
+        options.regionName = regionName;
+
+        // define a URIMap to CICS
+        try {
+            response = await defineUrimapServer(session, options);
+        } catch (err) {
+            error = err;
+        }
+
+        expect(error).toBeFalsy();
+        expect(response).toBeTruthy();
+        response = null; // reset
+
+        // define the same URIMap and validate duplicate error
+        try {
+            response = await defineUrimapServer(session, options);
+        } catch (err) {
+            error = err;
+        }
+
+        expect(error).toBeTruthy();
+        expect(response).toBeFalsy();
+        expect(error.message).toContain("Did not receive the expected response from CMCI REST API");
+        expect(error.message).toContain("DUPRES");
+        await deleteUrimap(session, options);
+    });
+});

--- a/__tests__/__system__/cli/define/urimap-client/__scripts__/define_urimap_client.sh
+++ b/__tests__/__system__/cli/define/urimap-client/__scripts__/define_urimap_client.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e # fail the script if we get a non zero exit code
+
+urimap_name=$1
+csd_group=$2
+urimap_path=$3
+urimap_host=$4
+region_name=$5
+
+zowe cics define urimap-client "$urimap_name" "$csd_group" --urimap-path "$urimap_path" --urimap-host "$urimap_host" --region-name "$region_name"

--- a/__tests__/__system__/cli/define/urimap-client/__scripts__/define_urimap_client_fully_qualified.sh
+++ b/__tests__/__system__/cli/define/urimap-client/__scripts__/define_urimap_client_fully_qualified.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e # fail the script if we get a non zero exit code
+
+urimap_name=$1
+csd_group=$2
+urimap_path=$3
+urimap_host=$4
+urimap_scheme=$5
+region_name=$6
+HOST=$7
+PORT=$8
+USER=$9
+PASSWORD=${10}
+PROTOCOL=${11}
+REJECT=${12}
+zowe cics define urimap-client "$urimap_name" "$csd_group" --urimap-path "$urimap_path" --urimap-host "$urimap_host" --urimap-scheme "$urimap_scheme" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"

--- a/__tests__/__system__/cli/define/urimap-client/__scripts__/define_urimap_client_help.sh
+++ b/__tests__/__system__/cli/define/urimap-client/__scripts__/define_urimap_client_help.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e # fail the script if we get a non zero exit code
+
+zowe cics define urimap-client --help

--- a/__tests__/__system__/cli/define/urimap-client/__scripts__/get_resource_urimap.sh
+++ b/__tests__/__system__/cli/define/urimap-client/__scripts__/get_resource_urimap.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e # fail the script if we get a non zero exit code
+
+region_name=$1
+csd_group=$2
+
+zowe cics get resource CICSDefinitionURIMap --region-name "$region_name" --parameter "CSDGROUP($csd_group)"

--- a/__tests__/__system__/cli/define/urimap-client/__scripts__/get_resource_urimap_fully_qualified.sh
+++ b/__tests__/__system__/cli/define/urimap-client/__scripts__/get_resource_urimap_fully_qualified.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e # fail the script if we get a non zero exit code
+
+region_name=$1
+csd_group=$2
+HOST=$3
+PORT=$4
+USER=$5
+PASSWORD=$6
+PROTOCOL=$7
+REJECT=$8
+
+zowe cics get resource CICSDefinitionURIMap --region-name "$region_name" --parameter "CSDGROUP($csd_group)" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"

--- a/__tests__/__system__/cli/define/urimap-client/__snapshots__/cli.define.urimap.client.system.test.ts.snap
+++ b/__tests__/__system__/cli/define/urimap-client/__snapshots__/cli.define.urimap.client.system.test.ts.snap
@@ -1,0 +1,132 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CICS define urimap-client command should be able to display the help 1`] = `
+"
+ COMMAND NAME
+ ------------
+
+   urimap-client
+
+ DESCRIPTION
+ -----------
+
+   Define a new URIMAP of type client to CICS. This acts as an HTTP(S) client
+
+ USAGE
+ -----
+
+   zowe cics define urimap-client <urimapName> <csdGroup> [options]
+
+ POSITIONAL ARGUMENTS
+ --------------------
+
+   urimapName		 (string)
+
+      The name of the URIMAP to create. The maximum length of the program name is
+      eight characters.
+
+   csdGroup		 (string)
+
+      The CICS system definition (CSD) Group for the new transaction that you want to
+      define. The maximum length of the group name is eight characters.
+
+ REQUIRED OPTIONS
+ ----------------
+
+   --urimap-path  | --up (string)
+
+      The path component of the URI
+
+   --urimap-host  | --uh (string)
+
+      The host component of the URI
+
+ OPTIONS
+ -------
+
+   --urimap-scheme  | --us (string)
+
+      The scheme component to be used with the request (http or https)
+
+      Default value: http
+      Allowed values: http, https
+
+   --region-name  (string)
+
+      The CICS region name to which to define the new URIMAP
+
+   --cics-plex  (string)
+
+      The name of the CICSPlex to which to define the new URIMAP
+
+ CICS CONNECTION OPTIONS
+ -----------------------
+
+   --host  | -H (string)
+
+      The CICS server host name.
+
+   --port  | -P (number)
+
+      The CICS server port.
+
+      Default value: 443
+
+   --user  | -u (string)
+
+      Mainframe (CICS) user name, which can be the same as your TSO login.
+
+   --password  | --pw (string)
+
+      Mainframe (CICS) password, which can be the same as your TSO password.
+
+   --reject-unauthorized  | --ru (boolean)
+
+      Reject self-signed certificates.
+
+      Default value: true
+
+   --protocol  | -o (string)
+
+      Specifies CMCI protocol (http or https).
+
+      Default value: http
+      Allowed values: http, https
+
+ PROFILE OPTIONS
+ ---------------
+
+   --cics-profile  | --cics-p (string)
+
+      The name of a (cics) profile to load for this command execution.
+
+ GLOBAL OPTIONS
+ --------------
+
+   --response-format-json  | --rfj (boolean)
+
+      Produce JSON formatted data from a command
+
+   --help  | -h (boolean)
+
+      Display help text
+
+   --help-examples  (boolean)
+
+      Display examples for all the commands in a the group
+
+   --help-web  | --hw (boolean)
+
+      Display HTML help in browser
+
+ EXAMPLES
+ --------
+
+   - Define a URIMAP named URIMAPA to the region named MYREGION
+   in the CSD group MYGRP where the host is www.example.com and the path is
+   /example/index.html:
+
+      $ zowe cics define urimap-client URIMAPA MYGRP --urimap-path /example/index.html --urimap-host www.example.com --region-name MYREGION
+
+"
+`;

--- a/__tests__/__system__/cli/define/urimap-client/cli.define.urimap.client.system.test.ts
+++ b/__tests__/__system__/cli/define/urimap-client/cli.define.urimap.client.system.test.ts
@@ -1,0 +1,155 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { TestEnvironment } from "../../../../__src__/environment/TestEnvironment";
+import { ITestEnvironment } from "../../../../__src__/environment/doc/response/ITestEnvironment";
+import { generateRandomAlphaNumericString, runCliScript } from "../../../../__src__/TestUtils";
+import { Session } from "@zowe/imperative";
+import { IURIMapParms } from "../../../../../src";
+import { deleteUrimap } from "../../../../../src/api/methods/delete/Delete";
+
+let TEST_ENVIRONMENT: ITestEnvironment;
+let regionName: string;
+let csdGroup: string;
+let host: string;
+let port: number;
+let user: string;
+let password: string;
+let protocol: string;
+let rejectUnauthorized: boolean;
+let session: Session;
+
+describe("CICS define urimap-client command", () => {
+
+    beforeAll(async () => {
+        TEST_ENVIRONMENT = await TestEnvironment.setUp({
+            testName: "define_urimap_client",
+            installPlugin: true,
+            tempProfileTypes: ["cics"]
+        });
+        const cmciProperties = TEST_ENVIRONMENT.systemTestProperties.cmci;
+        csdGroup = TEST_ENVIRONMENT.systemTestProperties.cmci.csdGroup;
+        regionName = TEST_ENVIRONMENT.systemTestProperties.cmci.regionName;
+        host = TEST_ENVIRONMENT.systemTestProperties.cmci.host;
+        port = TEST_ENVIRONMENT.systemTestProperties.cmci.port;
+        user = TEST_ENVIRONMENT.systemTestProperties.cmci.user;
+        password = TEST_ENVIRONMENT.systemTestProperties.cmci.password;
+        protocol = TEST_ENVIRONMENT.systemTestProperties.cmci.protocol;
+        rejectUnauthorized = TEST_ENVIRONMENT.systemTestProperties.cmci.rejectUnauthorized;
+        session = new Session({
+            type: "basic",
+            hostname: cmciProperties.host,
+            port: cmciProperties.port,
+            user: cmciProperties.user,
+            password: cmciProperties.password,
+            strictSSL: false,
+            protocol: "http",
+        });
+    });
+
+    afterAll(async () => {
+        await TestEnvironment.cleanUp(TEST_ENVIRONMENT);
+    });
+
+    it("should be able to display the help", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_client_help.sh", TEST_ENVIRONMENT, []);
+        expect(output.stderr.toString()).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toMatchSnapshot();
+    });
+
+    it("should be able to successfully define a client urimap with basic options", async () => {
+        const urimapNameSuffixLength = 4;
+        const urimapName = "DFN" + generateRandomAlphaNumericString(urimapNameSuffixLength);
+        const options: IURIMapParms = { name: urimapName, csdGroup, regionName };
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_client.sh", TEST_ENVIRONMENT,
+            [urimapName, csdGroup, "urimap/test/invalid.html", "www.example.com", regionName]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toContain("success");
+        await deleteUrimap(session, options);
+    });
+
+    it("should get a syntax error if urimap name is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_client.sh", TEST_ENVIRONMENT,
+            ["", "FAKEGRP", "FAKEPATH", "FAKEHOST", "FAKERGN"]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("urimap");
+        expect(stderr).toContain("name");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should get a syntax error if CSD group is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_client.sh", TEST_ENVIRONMENT,
+            ["FAKESRV", "", "FAKEPATH", "FAKEHOST", "FAKERGN"]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("csdGroup");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should get a syntax error if urimap path is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_client.sh", TEST_ENVIRONMENT,
+            ["FAKESRV", "FAKEGRP", "", "FAKEHOST", "FAKERGN"]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("urimap-path");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should get a syntax error if urimap host is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_client.sh", TEST_ENVIRONMENT,
+            ["FAKESRV", "FAKEGRP", "FAKEPATH", "", "FAKERGN"]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("urimap-host");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should get a syntax error if region name is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_client.sh", TEST_ENVIRONMENT,
+            ["FAKESRV", "FAKEGRP", "FAKEPATH", "FAKEHOST", ""]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("region-name");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should be able to successfully define a client urimap using profile options", async () => {
+        const urimapNameSuffixLength = 4;
+        const urimapName = "DFN" + generateRandomAlphaNumericString(urimapNameSuffixLength);
+        const urimapHost = "www.example.com";
+        const urimapScheme = "http";
+        const urimapPath = "urimap/test/invalid.html";
+        const options: IURIMapParms = { name: urimapName, csdGroup, regionName };
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_client_fully_qualified.sh", TEST_ENVIRONMENT,
+            [urimapName,
+                csdGroup,
+                urimapPath,
+                urimapHost,
+                urimapScheme,
+                regionName,
+                host,
+                port,
+                user,
+                password,
+                protocol,
+                rejectUnauthorized]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toContain("success");
+        await deleteUrimap(session, options);
+    });
+
+});

--- a/__tests__/__system__/cli/define/urimap-client/cli.define.urimap.client.system.test.ts
+++ b/__tests__/__system__/cli/define/urimap-client/cli.define.urimap.client.system.test.ts
@@ -14,6 +14,7 @@ import { ITestEnvironment } from "../../../../__src__/environment/doc/response/I
 import { generateRandomAlphaNumericString, runCliScript } from "../../../../__src__/TestUtils";
 import { Session } from "@zowe/imperative";
 import { IURIMapParms } from "../../../../../src";
+import { getResource } from "../../../../../src/api/methods/get/Get";
 import { deleteUrimap } from "../../../../../src/api/methods/delete/Delete";
 
 let TEST_ENVIRONMENT: ITestEnvironment;
@@ -70,12 +71,22 @@ describe("CICS define urimap-client command", () => {
         const urimapNameSuffixLength = 4;
         const urimapName = "DFN" + generateRandomAlphaNumericString(urimapNameSuffixLength);
         const options: IURIMapParms = { name: urimapName, csdGroup, regionName };
-        const output = runCliScript(__dirname + "/__scripts__/define_urimap_client.sh", TEST_ENVIRONMENT,
+        let output = runCliScript(__dirname + "/__scripts__/define_urimap_client.sh", TEST_ENVIRONMENT,
             [urimapName, csdGroup, "urimap/test/invalid.html", "www.example.com", regionName]);
-        const stderr = output.stderr.toString();
+        let stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
         expect(output.stdout.toString()).toContain("success");
+
+        output = runCliScript(__dirname + "/__scripts__/get_resource_urimap.sh", TEST_ENVIRONMENT,
+            [regionName,
+                csdGroup]);
+        stderr = output.stderr.toString();
+        expect(stderr).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toContain(urimapName);
+        expect(output.stdout.toString()).toContain("ENABLED");
+
         await deleteUrimap(session, options);
     });
 
@@ -132,7 +143,7 @@ describe("CICS define urimap-client command", () => {
         const urimapScheme = "http";
         const urimapPath = "urimap/test/invalid.html";
         const options: IURIMapParms = { name: urimapName, csdGroup, regionName };
-        const output = runCliScript(__dirname + "/__scripts__/define_urimap_client_fully_qualified.sh", TEST_ENVIRONMENT,
+        let output = runCliScript(__dirname + "/__scripts__/define_urimap_client_fully_qualified.sh", TEST_ENVIRONMENT,
             [urimapName,
                 csdGroup,
                 urimapPath,
@@ -145,10 +156,26 @@ describe("CICS define urimap-client command", () => {
                 password,
                 protocol,
                 rejectUnauthorized]);
-        const stderr = output.stderr.toString();
+        let stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
         expect(output.stdout.toString()).toContain("success");
+
+        output = runCliScript(__dirname + "/__scripts__/get_resource_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
+            [regionName,
+                csdGroup,
+                host,
+                port,
+                user,
+                password,
+                protocol,
+                rejectUnauthorized]);
+        stderr = output.stderr.toString();
+        expect(stderr).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toContain(urimapName);
+        expect(output.stdout.toString()).toContain("ENABLED");
+
         await deleteUrimap(session, options);
     });
 

--- a/__tests__/__system__/cli/define/urimap-pipeline/__scripts__/define_urimap_pipeline.sh
+++ b/__tests__/__system__/cli/define/urimap-pipeline/__scripts__/define_urimap_pipeline.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e # fail the script if we get a non zero exit code
+
+urimap_name=$1
+csd_group=$2
+urimap_path=$3
+urimap_host=$4
+pipeline_name=$5
+region_name=$6
+
+zowe cics define urimap-pipeline "$urimap_name" "$csd_group" --urimap-path "$urimap_path" --urimap-host "$urimap_host" --pipeline-name "$pipeline_name" --region-name "$region_name"

--- a/__tests__/__system__/cli/define/urimap-pipeline/__scripts__/define_urimap_pipeline_fully_qualified.sh
+++ b/__tests__/__system__/cli/define/urimap-pipeline/__scripts__/define_urimap_pipeline_fully_qualified.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e # fail the script if we get a non zero exit code
+
+urimap_name=$1
+csd_group=$2
+urimap_path=$3
+urimap_host=$4
+urimap_scheme=$5
+pipeline_name=$6
+region_name=$7
+HOST=$8
+PORT=$9
+USER=${10}
+PASSWORD=${11}
+PROTOCOL=${12}
+REJECT=${13}
+zowe cics define urimap-pipeline "$urimap_name" "$csd_group" --urimap-path "$urimap_path" --urimap-host "$urimap_host" --urimap-scheme "$urimap_scheme" --pipeline-name "$pipeline_name" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"

--- a/__tests__/__system__/cli/define/urimap-pipeline/__scripts__/define_urimap_pipeline_help.sh
+++ b/__tests__/__system__/cli/define/urimap-pipeline/__scripts__/define_urimap_pipeline_help.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e # fail the script if we get a non zero exit code
+
+zowe cics define urimap-pipeline --help

--- a/__tests__/__system__/cli/define/urimap-pipeline/__scripts__/get_resource_urimap.sh
+++ b/__tests__/__system__/cli/define/urimap-pipeline/__scripts__/get_resource_urimap.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e # fail the script if we get a non zero exit code
+
+region_name=$1
+csd_group=$2
+
+zowe cics get resource CICSDefinitionURIMap --region-name "$region_name" --parameter "CSDGROUP($csd_group)"

--- a/__tests__/__system__/cli/define/urimap-pipeline/__scripts__/get_resource_urimap_fully_qualified.sh
+++ b/__tests__/__system__/cli/define/urimap-pipeline/__scripts__/get_resource_urimap_fully_qualified.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e # fail the script if we get a non zero exit code
+
+region_name=$1
+csd_group=$2
+HOST=$3
+PORT=$4
+USER=$5
+PASSWORD=$6
+PROTOCOL=$7
+REJECT=$8
+
+zowe cics get resource CICSDefinitionURIMap --region-name "$region_name" --parameter "CSDGROUP($csd_group)" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"

--- a/__tests__/__system__/cli/define/urimap-pipeline/__snapshots__/cli.define.urimap_pipeline.system.test.ts.snap
+++ b/__tests__/__system__/cli/define/urimap-pipeline/__snapshots__/cli.define.urimap_pipeline.system.test.ts.snap
@@ -1,0 +1,138 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CICS define urimap-pipeline command should be able to display the help 1`] = `
+"
+ COMMAND NAME
+ ------------
+
+   urimap-pipeline
+
+ DESCRIPTION
+ -----------
+
+   Define a new URIMAP of type pipeline to CICS. This processes incoming HTTP(S)
+   requests
+
+ USAGE
+ -----
+
+   zowe cics define urimap-pipeline <urimapName> <csdGroup> [options]
+
+ POSITIONAL ARGUMENTS
+ --------------------
+
+   urimapName		 (string)
+
+      The name of the URIMAP to create. The maximum length of the program name is
+      eight characters.
+
+   csdGroup		 (string)
+
+      The CICS system definition (CSD) Group for the new transaction that you want to
+      define. The maximum length of the group name is eight characters.
+
+ REQUIRED OPTIONS
+ ----------------
+
+   --urimap-path  | --up (string)
+
+      The path component of the URI
+
+   --urimap-host  | --uh (string)
+
+      The host component of the URI
+
+   --pipeline-name  | --pn (string)
+
+      The name of the PIPELINE resource definition for the web service. The maximum
+      length of the pipeline name is eight characters
+
+ OPTIONS
+ -------
+
+   --urimap-scheme  | --us (string)
+
+      The scheme component to be used with the request (http or https)
+
+      Default value: http
+      Allowed values: http, https
+
+   --region-name  (string)
+
+      The CICS region name to which to define the new URIMAP
+
+   --cics-plex  (string)
+
+      The name of the CICSPlex to which to define the new URIMAP
+
+ CICS CONNECTION OPTIONS
+ -----------------------
+
+   --host  | -H (string)
+
+      The CICS server host name.
+
+   --port  | -P (number)
+
+      The CICS server port.
+
+      Default value: 443
+
+   --user  | -u (string)
+
+      Mainframe (CICS) user name, which can be the same as your TSO login.
+
+   --password  | --pw (string)
+
+      Mainframe (CICS) password, which can be the same as your TSO password.
+
+   --reject-unauthorized  | --ru (boolean)
+
+      Reject self-signed certificates.
+
+      Default value: true
+
+   --protocol  | -o (string)
+
+      Specifies CMCI protocol (http or https).
+
+      Default value: http
+      Allowed values: http, https
+
+ PROFILE OPTIONS
+ ---------------
+
+   --cics-profile  | --cics-p (string)
+
+      The name of a (cics) profile to load for this command execution.
+
+ GLOBAL OPTIONS
+ --------------
+
+   --response-format-json  | --rfj (boolean)
+
+      Produce JSON formatted data from a command
+
+   --help  | -h (boolean)
+
+      Display help text
+
+   --help-examples  (boolean)
+
+      Display examples for all the commands in a the group
+
+   --help-web  | --hw (boolean)
+
+      Display HTML help in browser
+
+ EXAMPLES
+ --------
+
+   - Define a URIMAP named URIMAPA to the region named MYREGION
+   in the CSD group MYGRP where the host is www.example.com and the path is
+   /example/index.html:
+
+      $ zowe cics define urimap-pipeline URIMAPA MYGRP --urimap-path /example/index.html --urimap-host www.example.com --pipeline-name PIPE123 --region-name MYREGION
+
+"
+`;

--- a/__tests__/__system__/cli/define/urimap-pipeline/cli.define.urimap.pipeline.system.test.ts
+++ b/__tests__/__system__/cli/define/urimap-pipeline/cli.define.urimap.pipeline.system.test.ts
@@ -70,12 +70,22 @@ describe("CICS define urimap-pipeline command", () => {
         const urimapNameSuffixLength = 4;
         const urimapName = "DFN" + generateRandomAlphaNumericString(urimapNameSuffixLength);
         const options: IURIMapParms = { name: urimapName, csdGroup, regionName };
-        const output = runCliScript(__dirname + "/__scripts__/define_urimap_pipeline.sh", TEST_ENVIRONMENT,
+        let output = runCliScript(__dirname + "/__scripts__/define_urimap_pipeline.sh", TEST_ENVIRONMENT,
             [urimapName, csdGroup, "urimap/test/invalid.html", "www.example.com", "FAKEPIPE", regionName]);
-        const stderr = output.stderr.toString();
+        let stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
         expect(output.stdout.toString()).toContain("success");
+
+        output = runCliScript(__dirname + "/__scripts__/get_resource_urimap.sh", TEST_ENVIRONMENT,
+            [regionName,
+                csdGroup]);
+        stderr = output.stderr.toString();
+        expect(stderr).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toContain(urimapName);
+        expect(output.stdout.toString()).toContain("ENABLED");
+
         await deleteUrimap(session, options);
     });
 
@@ -142,7 +152,7 @@ describe("CICS define urimap-pipeline command", () => {
         const urimapPath = "urimap/test/invalid.html";
         const pipelineName = "FAKEPIPE";
         const options: IURIMapParms = { name: urimapName, csdGroup, regionName };
-        const output = runCliScript(__dirname + "/__scripts__/define_urimap_pipeline_fully_qualified.sh", TEST_ENVIRONMENT,
+        let output = runCliScript(__dirname + "/__scripts__/define_urimap_pipeline_fully_qualified.sh", TEST_ENVIRONMENT,
             [urimapName,
                 csdGroup,
                 urimapPath,
@@ -156,10 +166,26 @@ describe("CICS define urimap-pipeline command", () => {
                 password,
                 protocol,
                 rejectUnauthorized]);
-        const stderr = output.stderr.toString();
+        let stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
         expect(output.stdout.toString()).toContain("success");
+
+        output = runCliScript(__dirname + "/__scripts__/get_resource_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
+            [regionName,
+                csdGroup,
+                host,
+                port,
+                user,
+                password,
+                protocol,
+                rejectUnauthorized]);
+        stderr = output.stderr.toString();
+        expect(stderr).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toContain(urimapName);
+        expect(output.stdout.toString()).toContain("ENABLED");
+
         await deleteUrimap(session, options);
     });
 

--- a/__tests__/__system__/cli/define/urimap-pipeline/cli.define.urimap.pipeline.system.test.ts
+++ b/__tests__/__system__/cli/define/urimap-pipeline/cli.define.urimap.pipeline.system.test.ts
@@ -1,0 +1,166 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { TestEnvironment } from "../../../../__src__/environment/TestEnvironment";
+import { ITestEnvironment } from "../../../../__src__/environment/doc/response/ITestEnvironment";
+import { generateRandomAlphaNumericString, runCliScript } from "../../../../__src__/TestUtils";
+import { Session } from "@zowe/imperative";
+import { IURIMapParms } from "../../../../../src";
+import { deleteUrimap } from "../../../../../src/api/methods/delete/Delete";
+
+let TEST_ENVIRONMENT: ITestEnvironment;
+let regionName: string;
+let csdGroup: string;
+let host: string;
+let port: number;
+let user: string;
+let password: string;
+let protocol: string;
+let rejectUnauthorized: boolean;
+let session: Session;
+
+describe("CICS define urimap-pipeline command", () => {
+
+    beforeAll(async () => {
+        TEST_ENVIRONMENT = await TestEnvironment.setUp({
+            testName: "define_urimap_pipeline",
+            installPlugin: true,
+            tempProfileTypes: ["cics"]
+        });
+        const cmciProperties = TEST_ENVIRONMENT.systemTestProperties.cmci;
+        csdGroup = TEST_ENVIRONMENT.systemTestProperties.cmci.csdGroup;
+        regionName = TEST_ENVIRONMENT.systemTestProperties.cmci.regionName;
+        host = TEST_ENVIRONMENT.systemTestProperties.cmci.host;
+        port = TEST_ENVIRONMENT.systemTestProperties.cmci.port;
+        user = TEST_ENVIRONMENT.systemTestProperties.cmci.user;
+        password = TEST_ENVIRONMENT.systemTestProperties.cmci.password;
+        protocol = TEST_ENVIRONMENT.systemTestProperties.cmci.protocol;
+        rejectUnauthorized = TEST_ENVIRONMENT.systemTestProperties.cmci.rejectUnauthorized;
+        session = new Session({
+            type: "basic",
+            hostname: cmciProperties.host,
+            port: cmciProperties.port,
+            user: cmciProperties.user,
+            password: cmciProperties.password,
+            strictSSL: false,
+            protocol: "http",
+        });
+    });
+
+    afterAll(async () => {
+        await TestEnvironment.cleanUp(TEST_ENVIRONMENT);
+    });
+
+    it("should be able to display the help", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_pipeline_help.sh", TEST_ENVIRONMENT, []);
+        expect(output.stderr.toString()).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toMatchSnapshot();
+    });
+
+    it("should be able to successfully define a pipeline urimap with basic options", async () => {
+        const urimapNameSuffixLength = 4;
+        const urimapName = "DFN" + generateRandomAlphaNumericString(urimapNameSuffixLength);
+        const options: IURIMapParms = { name: urimapName, csdGroup, regionName };
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_pipeline.sh", TEST_ENVIRONMENT,
+            [urimapName, csdGroup, "urimap/test/invalid.html", "www.example.com", "FAKEPIPE", regionName]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toContain("success");
+        await deleteUrimap(session, options);
+    });
+
+    it("should get a syntax error if urimap name is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_pipeline.sh", TEST_ENVIRONMENT,
+            ["", "FAKEGRP", "FAKEPATH", "FAKEHOST", "FAKEPIPE", "FAKERGN"]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("urimap");
+        expect(stderr).toContain("name");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should get a syntax error if CSD group is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_pipeline.sh", TEST_ENVIRONMENT,
+            ["FAKESRV", "", "FAKEPATH", "FAKEHOST", "FAKEPIPE", "FAKERGN"]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("csdGroup");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should get a syntax error if urimap path is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_pipeline.sh", TEST_ENVIRONMENT,
+            ["FAKESRV", "FAKEGRP", "", "FAKEHOST", "FAKEPIPE", "FAKERGN"]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("urimap-path");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should get a syntax error if urimap host is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_pipeline.sh", TEST_ENVIRONMENT,
+            ["FAKESRV", "FAKEGRP", "FAKEPATH", "", "FAKEPIPE", "FAKERGN"]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("urimap-host");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should get a syntax error if pipeline name is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_pipeline.sh", TEST_ENVIRONMENT,
+            ["FAKESRV", "FAKEGRP", "FAKEPATH", "FAKEHOST", "", "FAKERGN"]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("pipeline-name");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should get a syntax error if region name is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_pipeline.sh", TEST_ENVIRONMENT,
+            ["FAKESRV", "FAKEGRP", "FAKEPATH", "FAKEHOST", "FAKEPIPE", ""]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("region-name");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should be able to successfully define a pipeline urimap using profile options", async () => {
+        const urimapNameSuffixLength = 4;
+        const urimapName = "DFN" + generateRandomAlphaNumericString(urimapNameSuffixLength);
+        const urimapHost = "www.example.com";
+        const urimapScheme = "http";
+        const urimapPath = "urimap/test/invalid.html";
+        const pipelineName = "FAKEPIPE";
+        const options: IURIMapParms = { name: urimapName, csdGroup, regionName };
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_pipeline_fully_qualified.sh", TEST_ENVIRONMENT,
+            [urimapName,
+                csdGroup,
+                urimapPath,
+                urimapHost,
+                urimapScheme,
+                pipelineName,
+                regionName,
+                host,
+                port,
+                user,
+                password,
+                protocol,
+                rejectUnauthorized]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toContain("success");
+        await deleteUrimap(session, options);
+    });
+
+});

--- a/__tests__/__system__/cli/define/urimap-server/__scripts__/define_urimap_server.sh
+++ b/__tests__/__system__/cli/define/urimap-server/__scripts__/define_urimap_server.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e # fail the script if we get a non zero exit code
+
+urimap_name=$1
+csd_group=$2
+urimap_path=$3
+urimap_host=$4
+program_name=$5
+region_name=$6
+
+zowe cics define urimap-server "$urimap_name" "$csd_group" --urimap-path "$urimap_path" --urimap-host "$urimap_host" --program-name "$program_name" --region-name "$region_name"

--- a/__tests__/__system__/cli/define/urimap-server/__scripts__/define_urimap_server_fully_qualified.sh
+++ b/__tests__/__system__/cli/define/urimap-server/__scripts__/define_urimap_server_fully_qualified.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e # fail the script if we get a non zero exit code
+
+urimap_name=$1
+csd_group=$2
+urimap_path=$3
+urimap_host=$4
+urimap_scheme=$5
+program_name=$6
+region_name=$7
+HOST=$8
+PORT=$9
+USER=${10}
+PASSWORD=${11}
+PROTOCOL=${12}
+REJECT=${13}
+zowe cics define urimap-server "$urimap_name" "$csd_group" --urimap-path "$urimap_path" --urimap-host "$urimap_host" --urimap-scheme "$urimap_scheme" --program-name "$program_name" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"

--- a/__tests__/__system__/cli/define/urimap-server/__scripts__/define_urimap_server_help.sh
+++ b/__tests__/__system__/cli/define/urimap-server/__scripts__/define_urimap_server_help.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e # fail the script if we get a non zero exit code
+
+zowe cics define urimap-server --help

--- a/__tests__/__system__/cli/define/urimap-server/__scripts__/get_resource_urimap.sh
+++ b/__tests__/__system__/cli/define/urimap-server/__scripts__/get_resource_urimap.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e # fail the script if we get a non zero exit code
+
+region_name=$1
+csd_group=$2
+
+zowe cics get resource CICSDefinitionURIMap --region-name "$region_name" --parameter "CSDGROUP($csd_group)"

--- a/__tests__/__system__/cli/define/urimap-server/__scripts__/get_resource_urimap_fully_qualified.sh
+++ b/__tests__/__system__/cli/define/urimap-server/__scripts__/get_resource_urimap_fully_qualified.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e # fail the script if we get a non zero exit code
+
+region_name=$1
+csd_group=$2
+HOST=$3
+PORT=$4
+USER=$5
+PASSWORD=$6
+PROTOCOL=$7
+REJECT=$8
+
+zowe cics get resource CICSDefinitionURIMap --region-name "$region_name" --parameter "CSDGROUP($csd_group)" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"

--- a/__tests__/__system__/cli/define/urimap-server/__snapshots__/cli.define.urimap_server.system.test.ts.snap
+++ b/__tests__/__system__/cli/define/urimap-server/__snapshots__/cli.define.urimap_server.system.test.ts.snap
@@ -1,0 +1,136 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CICS define urimap-server command should be able to display the help 1`] = `
+"
+ COMMAND NAME
+ ------------
+
+   urimap-server
+
+ DESCRIPTION
+ -----------
+
+   Define a new URIMAP of type server to CICS. This acts as an HTTP(S) server
+
+ USAGE
+ -----
+
+   zowe cics define urimap-server <urimapName> <csdGroup> [options]
+
+ POSITIONAL ARGUMENTS
+ --------------------
+
+   urimapName		 (string)
+
+      The name of the URIMAP to create. The maximum length of the program name is
+      eight characters.
+
+   csdGroup		 (string)
+
+      The CICS system definition (CSD) Group for the new transaction that you want to
+      define. The maximum length of the group name is eight characters.
+
+ REQUIRED OPTIONS
+ ----------------
+
+   --urimap-path  | --up (string)
+
+      The path component of the URI
+
+   --urimap-host  | --uh (string)
+
+      The host component of the URI
+
+   --program-name  | --pn (string)
+
+      The application program that makes or handles the requests
+
+ OPTIONS
+ -------
+
+   --urimap-scheme  | --us (string)
+
+      The scheme component to be used with the request (http or https)
+
+      Default value: http
+      Allowed values: http, https
+
+   --region-name  (string)
+
+      The CICS region name to which to define the new URIMAP
+
+   --cics-plex  (string)
+
+      The name of the CICSPlex to which to define the new URIMAP
+
+ CICS CONNECTION OPTIONS
+ -----------------------
+
+   --host  | -H (string)
+
+      The CICS server host name.
+
+   --port  | -P (number)
+
+      The CICS server port.
+
+      Default value: 443
+
+   --user  | -u (string)
+
+      Mainframe (CICS) user name, which can be the same as your TSO login.
+
+   --password  | --pw (string)
+
+      Mainframe (CICS) password, which can be the same as your TSO password.
+
+   --reject-unauthorized  | --ru (boolean)
+
+      Reject self-signed certificates.
+
+      Default value: true
+
+   --protocol  | -o (string)
+
+      Specifies CMCI protocol (http or https).
+
+      Default value: http
+      Allowed values: http, https
+
+ PROFILE OPTIONS
+ ---------------
+
+   --cics-profile  | --cics-p (string)
+
+      The name of a (cics) profile to load for this command execution.
+
+ GLOBAL OPTIONS
+ --------------
+
+   --response-format-json  | --rfj (boolean)
+
+      Produce JSON formatted data from a command
+
+   --help  | -h (boolean)
+
+      Display help text
+
+   --help-examples  (boolean)
+
+      Display examples for all the commands in a the group
+
+   --help-web  | --hw (boolean)
+
+      Display HTML help in browser
+
+ EXAMPLES
+ --------
+
+   - Define a URIMAP named URIMAPA for the program named PGM123
+   to the region named MYREGION in the CSD group MYGRP where the host is
+   www.example.com and the path is /example/index.html:
+
+      $ zowe cics define urimap-server URIMAPA MYGRP --urimap-path /example/index.html --urimap-host www.example.com --program-name PGM123 --region-name MYREGION
+
+"
+`;

--- a/__tests__/__system__/cli/define/urimap-server/cli.define.urimap.server.system.test.ts
+++ b/__tests__/__system__/cli/define/urimap-server/cli.define.urimap.server.system.test.ts
@@ -70,12 +70,22 @@ describe("CICS define urimap-server command", () => {
         const urimapNameSuffixLength = 4;
         const urimapName = "DFN" + generateRandomAlphaNumericString(urimapNameSuffixLength);
         const options: IURIMapParms = { name: urimapName, csdGroup, regionName };
-        const output = runCliScript(__dirname + "/__scripts__/define_urimap_server.sh", TEST_ENVIRONMENT,
+        let output = runCliScript(__dirname + "/__scripts__/define_urimap_server.sh", TEST_ENVIRONMENT,
             [urimapName, csdGroup, "urimap/test/invalid.html", "www.example.com", "IEFBR14", regionName]);
-        const stderr = output.stderr.toString();
+        let stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
         expect(output.stdout.toString()).toContain("success");
+
+        output = runCliScript(__dirname + "/__scripts__/get_resource_urimap.sh", TEST_ENVIRONMENT,
+            [regionName,
+                csdGroup]);
+        stderr = output.stderr.toString();
+        expect(stderr).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toContain(urimapName);
+        expect(output.stdout.toString()).toContain("ENABLED");
+
         await deleteUrimap(session, options);
     });
 
@@ -142,7 +152,7 @@ describe("CICS define urimap-server command", () => {
         const urimapPath = "urimap/test/invalid.html";
         const programName = "IEFBR14";
         const options: IURIMapParms = { name: urimapName, csdGroup, regionName };
-        const output = runCliScript(__dirname + "/__scripts__/define_urimap_server_fully_qualified.sh", TEST_ENVIRONMENT,
+        let output = runCliScript(__dirname + "/__scripts__/define_urimap_server_fully_qualified.sh", TEST_ENVIRONMENT,
             [urimapName,
                 csdGroup,
                 urimapPath,
@@ -156,10 +166,26 @@ describe("CICS define urimap-server command", () => {
                 password,
                 protocol,
                 rejectUnauthorized]);
-        const stderr = output.stderr.toString();
+        let stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
         expect(output.stdout.toString()).toContain("success");
+
+        output = runCliScript(__dirname + "/__scripts__/get_resource_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
+            [regionName,
+                csdGroup,
+                host,
+                port,
+                user,
+                password,
+                protocol,
+                rejectUnauthorized]);
+        stderr = output.stderr.toString();
+        expect(stderr).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toContain(urimapName);
+        expect(output.stdout.toString()).toContain("ENABLED");
+
         await deleteUrimap(session, options);
     });
 

--- a/__tests__/__system__/cli/define/urimap-server/cli.define.urimap.server.system.test.ts
+++ b/__tests__/__system__/cli/define/urimap-server/cli.define.urimap.server.system.test.ts
@@ -1,0 +1,166 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { TestEnvironment } from "../../../../__src__/environment/TestEnvironment";
+import { ITestEnvironment } from "../../../../__src__/environment/doc/response/ITestEnvironment";
+import { generateRandomAlphaNumericString, runCliScript } from "../../../../__src__/TestUtils";
+import { Session } from "@zowe/imperative";
+import { IURIMapParms } from "../../../../../src";
+import { deleteUrimap } from "../../../../../src/api/methods/delete/Delete";
+
+let TEST_ENVIRONMENT: ITestEnvironment;
+let regionName: string;
+let csdGroup: string;
+let host: string;
+let port: number;
+let user: string;
+let password: string;
+let protocol: string;
+let rejectUnauthorized: boolean;
+let session: Session;
+
+describe("CICS define urimap-server command", () => {
+
+    beforeAll(async () => {
+        TEST_ENVIRONMENT = await TestEnvironment.setUp({
+            testName: "define_urimap_server",
+            installPlugin: true,
+            tempProfileTypes: ["cics"]
+        });
+        const cmciProperties = TEST_ENVIRONMENT.systemTestProperties.cmci;
+        csdGroup = TEST_ENVIRONMENT.systemTestProperties.cmci.csdGroup;
+        regionName = TEST_ENVIRONMENT.systemTestProperties.cmci.regionName;
+        host = TEST_ENVIRONMENT.systemTestProperties.cmci.host;
+        port = TEST_ENVIRONMENT.systemTestProperties.cmci.port;
+        user = TEST_ENVIRONMENT.systemTestProperties.cmci.user;
+        password = TEST_ENVIRONMENT.systemTestProperties.cmci.password;
+        protocol = TEST_ENVIRONMENT.systemTestProperties.cmci.protocol;
+        rejectUnauthorized = TEST_ENVIRONMENT.systemTestProperties.cmci.rejectUnauthorized;
+        session = new Session({
+            type: "basic",
+            hostname: cmciProperties.host,
+            port: cmciProperties.port,
+            user: cmciProperties.user,
+            password: cmciProperties.password,
+            strictSSL: false,
+            protocol: "http",
+        });
+    });
+
+    afterAll(async () => {
+        await TestEnvironment.cleanUp(TEST_ENVIRONMENT);
+    });
+
+    it("should be able to display the help", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_server_help.sh", TEST_ENVIRONMENT, []);
+        expect(output.stderr.toString()).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toMatchSnapshot();
+    });
+
+    it("should be able to successfully define a server urimap with basic options", async () => {
+        const urimapNameSuffixLength = 4;
+        const urimapName = "DFN" + generateRandomAlphaNumericString(urimapNameSuffixLength);
+        const options: IURIMapParms = { name: urimapName, csdGroup, regionName };
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_server.sh", TEST_ENVIRONMENT,
+            [urimapName, csdGroup, "urimap/test/invalid.html", "www.example.com", "IEFBR14", regionName]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toContain("success");
+        await deleteUrimap(session, options);
+    });
+
+    it("should get a syntax error if urimap name is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_server.sh", TEST_ENVIRONMENT,
+            ["", "FAKEGRP", "FAKEPATH", "FAKEHOST", "FAKEPGM", "FAKERGN"]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("urimap");
+        expect(stderr).toContain("name");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should get a syntax error if CSD group is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_server.sh", TEST_ENVIRONMENT,
+            ["FAKESRV", "", "FAKEPATH", "FAKEHOST", "FAKEPGM", "FAKERGN"]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("csdGroup");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should get a syntax error if urimap path is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_server.sh", TEST_ENVIRONMENT,
+            ["FAKESRV", "FAKEGRP", "", "FAKEHOST", "FAKEPGM", "FAKERGN"]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("urimap-path");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should get a syntax error if urimap host is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_server.sh", TEST_ENVIRONMENT,
+            ["FAKESRV", "FAKEGRP", "FAKEPATH", "", "FAKEPGM", "FAKERGN"]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("urimap-host");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should get a syntax error if program name is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_server.sh", TEST_ENVIRONMENT,
+            ["FAKESRV", "FAKEGRP", "FAKEPATH", "FAKEHOST", "", "FAKERGN"]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("program-name");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should get a syntax error if region name is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_server.sh", TEST_ENVIRONMENT,
+            ["FAKESRV", "FAKEGRP", "FAKEPATH", "FAKEHOST", "FAKEPGM", ""]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("region-name");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should be able to successfully define a server urimap using profile options", async () => {
+        const urimapNameSuffixLength = 4;
+        const urimapName = "DFN" + generateRandomAlphaNumericString(urimapNameSuffixLength);
+        const urimapHost = "www.example.com";
+        const urimapScheme = "http";
+        const urimapPath = "urimap/test/invalid.html";
+        const programName = "IEFBR14";
+        const options: IURIMapParms = { name: urimapName, csdGroup, regionName };
+        const output = runCliScript(__dirname + "/__scripts__/define_urimap_server_fully_qualified.sh", TEST_ENVIRONMENT,
+            [urimapName,
+                csdGroup,
+                urimapPath,
+                urimapHost,
+                urimapScheme,
+                programName,
+                regionName,
+                host,
+                port,
+                user,
+                password,
+                protocol,
+                rejectUnauthorized]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toContain("success");
+        await deleteUrimap(session, options);
+    });
+
+});

--- a/__tests__/api/methods/define/Define.urimap-client.unit.test.ts
+++ b/__tests__/api/methods/define/Define.urimap-client.unit.test.ts
@@ -1,0 +1,362 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { Session } from "@zowe/imperative";
+import { CicsCmciRestClient, CicsCmciConstants, IURIMapParms, defineUrimapClient } from "../../../../src";
+
+describe("CMCI - Define client URIMap", () => {
+
+    const urimap = "urimap";
+    const path = "path";
+    const host = "host";
+    const scheme = "http";
+    const region = "region";
+    const group = "group";
+    const cicsPlex = "plex";
+    const content = "This\nis\r\na\ntest";
+
+    const defineParms: IURIMapParms  = {
+        regionName: region,
+        name: urimap,
+        path,
+        host,
+        scheme,
+        csdGroup: group,
+        cicsPlex: undefined
+    };
+
+    const dummySession = new Session({
+        user: "fake",
+        password: "fake",
+        hostname: "fake",
+        port: 1490
+    });
+
+    let error: any;
+    let response: any;
+    let endPoint: string;
+
+    describe("validation", () => {
+        beforeEach(() => {
+            response = undefined;
+            error = undefined;
+        });
+
+        it("should throw error if no parms are defined", async () => {
+            try {
+                response = await defineUrimapClient(dummySession, undefined);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Cannot read property 'name' of undefined");
+        });
+
+        it("should throw error if URIMap name is not defined", async () => {
+            try {
+                response = await defineUrimapClient(dummySession, {
+                    regionName: "fake",
+                    name: undefined,
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS URIMap name is required");
+        });
+
+        it("should throw error if CSD group is not defined", async () => {
+            try {
+                response = await defineUrimapClient(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    csdGroup: undefined
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS CSD group is required");
+        });
+
+        it("should throw error if URIMap path is not defined", async () => {
+            try {
+                response = await defineUrimapClient(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: undefined,
+                    host: "fake",
+                    scheme: "http",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS URIMap path is required");
+        });
+
+        it("should throw error if URIMap host is not defined", async () => {
+            try {
+                response = await defineUrimapClient(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: undefined,
+                    scheme: "http",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS URIMap host is required");
+        });
+
+        it("should throw error if URIMap scheme is not defined", async () => {
+            try {
+                response = await defineUrimapClient(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: undefined,
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS URIMap scheme is required");
+        });
+
+        it("should throw error if CICS Region name is not defined", async () => {
+            try {
+                response = await defineUrimapClient(dummySession, {
+                    regionName: undefined,
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS region name is required");
+        });
+
+        it("should throw error if URIMap name is missing", async () => {
+            try {
+                response = await defineUrimapClient(dummySession, {
+                    regionName: "fake",
+                    name: "",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS URIMap Name' must not be blank");
+        });
+
+        it("should throw error if CSD group is missing", async () => {
+            try {
+                response = await defineUrimapClient(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    csdGroup: ""
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS CSD Group' must not be blank");
+        });
+
+        it("should throw error if URIMap path is missing", async () => {
+            try {
+                response = await defineUrimapClient(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "",
+                    host: "fake",
+                    scheme: "http",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS URIMap Path' must not be blank");
+        });
+
+        it("should throw error if URIMap host is missing", async () => {
+            try {
+                response = await defineUrimapClient(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: "",
+                    scheme: "http",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS URIMap Host' must not be blank");
+        });
+
+        it("should throw error if URIMap scheme is missing", async () => {
+            try {
+                response = await defineUrimapClient(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS URIMap Scheme' must not be blank");
+        });
+
+        it("should throw error if CICS Region name is missing", async () => {
+            try {
+                response = await defineUrimapClient(dummySession, {
+                    regionName: "",
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS Region name' must not be blank");
+        });
+    });
+
+    describe("success scenarios", () => {
+
+        const requestBody: any = {
+            request: {
+                create: {
+                    parameter: {
+                        $: {
+                            name: "CSD",
+                        }
+                    },
+                    attributes: {
+                        $: {
+                            name: urimap,
+                            csdgroup: group,
+                            path,
+                            host,
+                            scheme,
+                            usage: "client"
+                        }
+                    }
+                }
+            }
+        };
+
+        const defineSpy = jest.spyOn(CicsCmciRestClient, "postExpectParsedXml").mockReturnValue(content);
+
+        beforeEach(() => {
+            response = undefined;
+            error = undefined;
+            defineSpy.mockClear();
+            defineSpy.mockImplementation(() => content);
+        });
+
+        it("should be able to define a URIMap without cicsPlex specified", async () => {
+            endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+                CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + region;
+
+            response = await defineUrimapClient(dummySession, defineParms);
+
+            // expect(response.success).toBe(true);
+            expect(response).toContain(content);
+            expect(defineSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+        });
+
+        it("should be able to define a URIMap with cicsPlex specified but empty string", async () => {
+            defineParms.cicsPlex = "";
+            endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+                CicsCmciConstants.CICS_DEFINITION_URIMAP + "//" + region;
+
+            response = await defineUrimapClient(dummySession, defineParms);
+
+            // expect(response.success).toBe(true);
+            expect(response).toContain(content);
+            expect(defineSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+        });
+
+        it("should be able to define a URIMap with cicsPlex specified", async () => {
+            defineParms.cicsPlex = cicsPlex;
+            endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+                CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex +"/" + region;
+
+            response = await defineUrimapClient(dummySession, defineParms);
+
+            // expect(response.success).toBe(true);
+            expect(response).toContain(content);
+            expect(defineSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+        });
+    });
+});

--- a/__tests__/api/methods/define/Define.urimap-pipeline.unit.test.ts
+++ b/__tests__/api/methods/define/Define.urimap-pipeline.unit.test.ts
@@ -1,0 +1,417 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { Session } from "@zowe/imperative";
+import { CicsCmciRestClient, CicsCmciConstants, IURIMapParms, defineUrimapPipeline } from "../../../../src";
+
+describe("CMCI - Define pipeline URIMap", () => {
+
+    const urimap = "urimap";
+    const path = "path";
+    const host = "host";
+    const scheme = "http";
+    const pipeline = "pipeline";
+    const region = "region";
+    const group = "group";
+    const cicsPlex = "plex";
+    const content = "This\nis\r\na\ntest";
+
+    const defineParms: IURIMapParms  = {
+        regionName: region,
+        name: urimap,
+        path,
+        host,
+        scheme,
+        pipelineName: pipeline,
+        csdGroup: group,
+        cicsPlex: undefined
+    };
+
+    const dummySession = new Session({
+        user: "fake",
+        password: "fake",
+        hostname: "fake",
+        port: 1490
+    });
+
+    let error: any;
+    let response: any;
+    let endPoint: string;
+
+    describe("validation", () => {
+        beforeEach(() => {
+            response = undefined;
+            error = undefined;
+        });
+
+        it("should throw error if no parms are defined", async () => {
+            try {
+                response = await defineUrimapPipeline(dummySession, undefined);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Cannot read property 'name' of undefined");
+        });
+
+        it("should throw error if URIMap name is not defined", async () => {
+            try {
+                response = await defineUrimapPipeline(dummySession, {
+                    regionName: "fake",
+                    name: undefined,
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    pipelineName: "fake",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS URIMap name is required");
+        });
+
+        it("should throw error if CSD group is not defined", async () => {
+            try {
+                response = await defineUrimapPipeline(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    pipelineName: "fake",
+                    csdGroup: undefined
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS CSD group is required");
+        });
+
+        it("should throw error if URIMap path is not defined", async () => {
+            try {
+                response = await defineUrimapPipeline(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: undefined,
+                    host: "fake",
+                    scheme: "http",
+                    pipelineName: "fake",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS URIMap path is required");
+        });
+
+        it("should throw error if URIMap host is not defined", async () => {
+            try {
+                response = await defineUrimapPipeline(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: undefined,
+                    scheme: "http",
+                    pipelineName: "fake",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS URIMap host is required");
+        });
+
+        it("should throw error if URIMap scheme is not defined", async () => {
+            try {
+                response = await defineUrimapPipeline(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: undefined,
+                    pipelineName: "fake",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS URIMap scheme is required");
+        });
+
+        it("should throw error if CICS Region name is not defined", async () => {
+            try {
+                response = await defineUrimapPipeline(dummySession, {
+                    regionName: undefined,
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    pipelineName: "fake",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS region name is required");
+        });
+
+        it("should throw error if pipeline name is not defined", async () => {
+            try {
+                response = await defineUrimapPipeline(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    pipelineName: undefined,
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS URIMap pipeline name is required");
+        });
+
+        it("should throw error if URIMap name is missing", async () => {
+            try {
+                response = await defineUrimapPipeline(dummySession, {
+                    regionName: "fake",
+                    name: "",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    pipelineName: "fake",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS URIMap Name' must not be blank");
+        });
+
+        it("should throw error if CSD group is missing", async () => {
+            try {
+                response = await defineUrimapPipeline(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    pipelineName: "fake",
+                    csdGroup: ""
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS CSD Group' must not be blank");
+        });
+
+        it("should throw error if URIMap path is missing", async () => {
+            try {
+                response = await defineUrimapPipeline(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "",
+                    host: "fake",
+                    scheme: "http",
+                    pipelineName: "fake",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS URIMap Path' must not be blank");
+        });
+
+        it("should throw error if URIMap host is missing", async () => {
+            try {
+                response = await defineUrimapPipeline(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: "",
+                    scheme: "http",
+                    pipelineName: "fake",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS URIMap Host' must not be blank");
+        });
+
+        it("should throw error if URIMap scheme is missing", async () => {
+            try {
+                response = await defineUrimapPipeline(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "",
+                    pipelineName: "fake",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS URIMap Scheme' must not be blank");
+        });
+
+        it("should throw error if CICS Region name is missing", async () => {
+            try {
+                response = await defineUrimapPipeline(dummySession, {
+                    regionName: "",
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    pipelineName: "fake",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS Region name' must not be blank");
+        });
+
+        it("should throw error if pipeline name is missing", async () => {
+            try {
+                response = await defineUrimapPipeline(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    pipelineName: "",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS URIMap Pipeline name' must not be blank");
+        });
+    });
+
+    describe("success scenarios", () => {
+
+        const requestBody: any = {
+            request: {
+                create: {
+                    parameter: {
+                        $: {
+                            name: "CSD",
+                        }
+                    },
+                    attributes: {
+                        $: {
+                            name: urimap,
+                            csdgroup: group,
+                            path,
+                            host,
+                            scheme,
+                            pipeline,
+                            usage: "pipeline"
+                        }
+                    }
+                }
+            }
+        };
+
+        const defineSpy = jest.spyOn(CicsCmciRestClient, "postExpectParsedXml").mockReturnValue(content);
+
+        beforeEach(() => {
+            response = undefined;
+            error = undefined;
+            defineSpy.mockClear();
+            defineSpy.mockImplementation(() => content);
+        });
+
+        it("should be able to define a URIMap without cicsPlex specified", async () => {
+            endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+                CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + region;
+
+            response = await defineUrimapPipeline(dummySession, defineParms);
+
+            // expect(response.success).toBe(true);
+            expect(response).toContain(content);
+            expect(defineSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+        });
+
+        it("should be able to define a URIMap with cicsPlex specified but empty string", async () => {
+            defineParms.cicsPlex = "";
+            endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+                CicsCmciConstants.CICS_DEFINITION_URIMAP + "//" + region;
+
+            response = await defineUrimapPipeline(dummySession, defineParms);
+
+            // expect(response.success).toBe(true);
+            expect(response).toContain(content);
+            expect(defineSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+        });
+
+        it("should be able to define a URIMap with cicsPlex specified", async () => {
+            defineParms.cicsPlex = cicsPlex;
+            endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+                CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex +"/" + region;
+
+            response = await defineUrimapPipeline(dummySession, defineParms);
+
+            // expect(response.success).toBe(true);
+            expect(response).toContain(content);
+            expect(defineSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+        });
+    });
+});

--- a/__tests__/api/methods/define/Define.urimap-server.unit.test.ts
+++ b/__tests__/api/methods/define/Define.urimap-server.unit.test.ts
@@ -1,0 +1,417 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { Session } from "@zowe/imperative";
+import { CicsCmciRestClient, CicsCmciConstants, IURIMapParms, defineUrimapServer } from "../../../../src";
+
+describe("CMCI - Define server URIMap", () => {
+
+    const urimap = "urimap";
+    const path = "path";
+    const host = "host";
+    const scheme = "http";
+    const program = "program";
+    const region = "region";
+    const group = "group";
+    const cicsPlex = "plex";
+    const content = "This\nis\r\na\ntest";
+
+    const defineParms: IURIMapParms  = {
+        regionName: region,
+        name: urimap,
+        path,
+        host,
+        scheme,
+        programName: program,
+        csdGroup: group,
+        cicsPlex: undefined
+    };
+
+    const dummySession = new Session({
+        user: "fake",
+        password: "fake",
+        hostname: "fake",
+        port: 1490
+    });
+
+    let error: any;
+    let response: any;
+    let endPoint: string;
+
+    describe("validation", () => {
+        beforeEach(() => {
+            response = undefined;
+            error = undefined;
+        });
+
+        it("should throw error if no parms are defined", async () => {
+            try {
+                response = await defineUrimapServer(dummySession, undefined);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Cannot read property 'name' of undefined");
+        });
+
+        it("should throw error if URIMap name is not defined", async () => {
+            try {
+                response = await defineUrimapServer(dummySession, {
+                    regionName: "fake",
+                    name: undefined,
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    programName: "fake",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS URIMap name is required");
+        });
+
+        it("should throw error if CSD group is not defined", async () => {
+            try {
+                response = await defineUrimapServer(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    programName: "fake",
+                    csdGroup: undefined
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS CSD group is required");
+        });
+
+        it("should throw error if URIMap path is not defined", async () => {
+            try {
+                response = await defineUrimapServer(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: undefined,
+                    host: "fake",
+                    scheme: "http",
+                    programName: "fake",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS URIMap path is required");
+        });
+
+        it("should throw error if URIMap host is not defined", async () => {
+            try {
+                response = await defineUrimapServer(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: undefined,
+                    scheme: "http",
+                    programName: "fake",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS URIMap host is required");
+        });
+
+        it("should throw error if URIMap scheme is not defined", async () => {
+            try {
+                response = await defineUrimapServer(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: undefined,
+                    programName: "fake",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS URIMap scheme is required");
+        });
+
+        it("should throw error if CICS Region name is not defined", async () => {
+            try {
+                response = await defineUrimapServer(dummySession, {
+                    regionName: undefined,
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    programName: "fake",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS region name is required");
+        });
+
+        it("should throw error if program name is not defined", async () => {
+            try {
+                response = await defineUrimapServer(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    programName: undefined,
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS URIMap program name is required");
+        });
+
+        it("should throw error if URIMap name is missing", async () => {
+            try {
+                response = await defineUrimapServer(dummySession, {
+                    regionName: "fake",
+                    name: "",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    programName: "fake",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS URIMap Name' must not be blank");
+        });
+
+        it("should throw error if CSD group is missing", async () => {
+            try {
+                response = await defineUrimapServer(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    programName: "fake",
+                    csdGroup: ""
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS CSD Group' must not be blank");
+        });
+
+        it("should throw error if URIMap path is missing", async () => {
+            try {
+                response = await defineUrimapServer(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "",
+                    host: "fake",
+                    scheme: "http",
+                    programName: "fake",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS URIMap Path' must not be blank");
+        });
+
+        it("should throw error if URIMap host is missing", async () => {
+            try {
+                response = await defineUrimapServer(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: "",
+                    scheme: "http",
+                    programName: "fake",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS URIMap Host' must not be blank");
+        });
+
+        it("should throw error if URIMap scheme is missing", async () => {
+            try {
+                response = await defineUrimapServer(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "",
+                    programName: "fake",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS URIMap Scheme' must not be blank");
+        });
+
+        it("should throw error if CICS Region name is missing", async () => {
+            try {
+                response = await defineUrimapServer(dummySession, {
+                    regionName: "",
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    programName: "fake",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS Region name' must not be blank");
+        });
+
+        it("should throw error if program name is missing", async () => {
+            try {
+                response = await defineUrimapServer(dummySession, {
+                    regionName: "fake",
+                    name: "fake",
+                    path: "fake",
+                    host: "fake",
+                    scheme: "http",
+                    programName: "",
+                    csdGroup: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS URIMap Program name' must not be blank");
+        });
+    });
+
+    describe("success scenarios", () => {
+
+        const requestBody: any = {
+            request: {
+                create: {
+                    parameter: {
+                        $: {
+                            name: "CSD",
+                        }
+                    },
+                    attributes: {
+                        $: {
+                            name: urimap,
+                            csdgroup: group,
+                            path,
+                            host,
+                            scheme,
+                            program,
+                            usage: "server"
+                        }
+                    }
+                }
+            }
+        };
+
+        const defineSpy = jest.spyOn(CicsCmciRestClient, "postExpectParsedXml").mockReturnValue(content);
+
+        beforeEach(() => {
+            response = undefined;
+            error = undefined;
+            defineSpy.mockClear();
+            defineSpy.mockImplementation(() => content);
+        });
+
+        it("should be able to define a URIMap without cicsPlex specified", async () => {
+            endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+                CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + region;
+
+            response = await defineUrimapServer(dummySession, defineParms);
+
+            // expect(response.success).toBe(true);
+            expect(response).toContain(content);
+            expect(defineSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+        });
+
+        it("should be able to define a URIMap with cicsPlex specified but empty string", async () => {
+            defineParms.cicsPlex = "";
+            endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+                CicsCmciConstants.CICS_DEFINITION_URIMAP + "//" + region;
+
+            response = await defineUrimapServer(dummySession, defineParms);
+
+            // expect(response.success).toBe(true);
+            expect(response).toContain(content);
+            expect(defineSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+        });
+
+        it("should be able to define a URIMap with cicsPlex specified", async () => {
+            defineParms.cicsPlex = cicsPlex;
+            endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+                CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex +"/" + region;
+
+            response = await defineUrimapServer(dummySession, defineParms);
+
+            // expect(response.success).toBe(true);
+            expect(response).toContain(content);
+            expect(defineSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+        });
+    });
+});

--- a/__tests__/cli/define/urimap-client/UrimapClient.definition.unit.test.ts
+++ b/__tests__/cli/define/urimap-client/UrimapClient.definition.unit.test.ts
@@ -11,14 +11,11 @@
 
 import { ICommandDefinition } from "@zowe/imperative";
 
-describe("cics define program", () => {
-    const DEFINE_RESOURCES = 5;
-
+describe("cics define urimap-client", () => {
     it ("should not have changed", () => {
-        const definition: ICommandDefinition = require("../../../src/cli/define/Define.definition");
+        const definition: ICommandDefinition = require("../../../../src/cli/define/urimap-client/UrimapClient.definition").UrimapClientDefinition;
         expect(definition).toBeDefined();
-        expect(definition.children.length).toBe(DEFINE_RESOURCES);
-        delete definition.children;
+        delete definition.handler;
         expect(definition).toMatchSnapshot();
     });
 });

--- a/__tests__/cli/define/urimap-client/UrimapClient.handler.unit.test.ts
+++ b/__tests__/cli/define/urimap-client/UrimapClient.handler.unit.test.ts
@@ -1,0 +1,144 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { CommandProfiles, IHandlerParameters, IProfile, Session } from "@zowe/imperative";
+import { ICMCIApiResponse } from "../../../../src";
+import { UrimapClientDefinition } from "../../../../src/cli/define/urimap-client/UrimapClient.definition";
+import UrimapClientHandler from "../../../../src/cli/define/urimap-client/UrimapClient.handler";
+
+jest.mock("../../../../src/api/methods/define");
+const Define = require("../../../../src/api/methods/define");
+
+const host = "somewhere.com";
+const port = "43443";
+const user = "someone";
+const password = "somesecret";
+const protocol = "http";
+const rejectUnauthorized = false;
+
+const PROFILE_MAP = new Map<string, IProfile[]>();
+PROFILE_MAP.set(
+    "cics", [{
+        name: "cics",
+        type: "cics",
+        host,
+        port,
+        user,
+        password
+    }]
+);
+const PROFILES: CommandProfiles = new CommandProfiles(PROFILE_MAP);
+const DEFAULT_PARAMETERS: IHandlerParameters = {
+    arguments: {$0: "", _: []}, // Please provide arguments later on
+    response: {
+        data: {
+            setMessage: jest.fn((setMsgArgs) => {
+                expect(setMsgArgs).toMatchSnapshot();
+            }),
+            setObj: jest.fn((setObjArgs) => {
+                expect(setObjArgs).toMatchSnapshot();
+            }),
+            setExitCode: jest.fn()
+        },
+        console: {
+            log: jest.fn((logs) => {
+                expect(logs.toString()).toMatchSnapshot();
+            }),
+            error: jest.fn((errors) => {
+                expect(errors.toString()).toMatchSnapshot();
+            }),
+            errorHeader: jest.fn(() => undefined)
+        },
+        progress: {
+            startBar: jest.fn((parms) => undefined),
+            endBar: jest.fn(() => undefined)
+        },
+        format: {
+            output: jest.fn((parms) => {
+                expect(parms).toMatchSnapshot();
+            })
+        }
+    },
+    definition: UrimapClientDefinition,
+    fullDefinition: UrimapClientDefinition,
+    profiles: PROFILES
+};
+
+describe("DefineUrimapClientHandler", () => {
+    const regionName = "testRegion";
+    const csdGroup = "testGroup";
+    const urimapName = "testUrimap";
+    const urimapHost = "testHost";
+    const urimapPath = "testPath";
+    const urimapScheme = "http";
+    const cicsPlex = "testPlex";
+
+    const defaultReturn: ICMCIApiResponse = {
+        response: {
+            resultsummary: {api_response1: "1024", api_response2: "0", recordcount: "0", displayed_recordcount: "0"},
+            records: "testing"
+        }
+    };
+
+    const functionSpy = jest.spyOn(Define, "defineUrimapClient");
+
+    beforeEach(() => {
+        functionSpy.mockClear();
+        functionSpy.mockImplementation(async () => defaultReturn);
+    });
+
+    it("should call the defineUrimapClient api", async () => {
+        const handler = new UrimapClientHandler();
+
+        const commandParameters = {...DEFAULT_PARAMETERS};
+        commandParameters.arguments = {
+            ...commandParameters.arguments,
+            urimapName,
+            csdGroup,
+            urimapPath,
+            urimapHost,
+            urimapScheme,
+            regionName,
+            cicsPlex,
+            host,
+            port,
+            user,
+            password,
+            rejectUnauthorized,
+            protocol
+        };
+
+        await handler.process(commandParameters);
+
+        expect(functionSpy).toHaveBeenCalledTimes(1);
+        const testProfile = PROFILE_MAP.get("cics")[0];
+        expect(functionSpy).toHaveBeenCalledWith(
+            new Session({
+                type: "basic",
+                hostname: testProfile.host,
+                port: testProfile.port,
+                user: testProfile.user,
+                password: testProfile.password,
+                rejectUnauthorized,
+                protocol
+            }),
+            {
+                name: urimapName,
+                csdGroup,
+                path: urimapPath,
+                host: urimapHost,
+                scheme: urimapScheme,
+                regionName,
+                cicsPlex
+            }
+        );
+    });
+});

--- a/__tests__/cli/define/urimap-client/__snapshots__/UrimapClient.definition.unit.test.ts.snap
+++ b/__tests__/cli/define/urimap-client/__snapshots__/UrimapClient.definition.unit.test.ts.snap
@@ -2,7 +2,9 @@
 
 exports[`cics define urimap-client should not have changed 1`] = `
 Object {
-  "aliases": Array [],
+  "aliases": Array [
+    "uc",
+  ],
   "description": "Define a new URIMAP of type client to CICS. This acts as an HTTP(S) client",
   "examples": Array [
     Object {

--- a/__tests__/cli/define/urimap-client/__snapshots__/UrimapClient.definition.unit.test.ts.snap
+++ b/__tests__/cli/define/urimap-client/__snapshots__/UrimapClient.definition.unit.test.ts.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cics define urimap-client should not have changed 1`] = `
+Object {
+  "aliases": Array [],
+  "description": "Define a new URIMAP of type client to CICS. This acts as an HTTP(S) client",
+  "examples": Array [
+    Object {
+      "description": "Define a URIMAP named URIMAPA to the region named MYREGION in the CSD group MYGRP where the host is www.example.com and the path is /example/index.html",
+      "options": "URIMAPA MYGRP --urimap-path /example/index.html --urimap-host www.example.com --region-name MYREGION",
+    },
+  ],
+  "name": "urimap-client",
+  "options": Array [
+    Object {
+      "aliases": Array [
+        "up",
+      ],
+      "description": "The path component of the URI",
+      "name": "urimap-path",
+      "required": true,
+      "type": "string",
+    },
+    Object {
+      "aliases": Array [
+        "uh",
+      ],
+      "description": "The host component of the URI",
+      "name": "urimap-host",
+      "required": true,
+      "type": "string",
+    },
+    Object {
+      "aliases": Array [
+        "us",
+      ],
+      "allowableValues": Object {
+        "caseSensitive": false,
+        "values": Array [
+          "http",
+          "https",
+        ],
+      },
+      "defaultValue": "http",
+      "description": "The scheme component to be used with the request (http or https)",
+      "name": "urimap-scheme",
+      "type": "string",
+    },
+    Object {
+      "description": "The CICS region name to which to define the new URIMAP",
+      "name": "region-name",
+      "type": "string",
+    },
+    Object {
+      "description": "The name of the CICSPlex to which to define the new URIMAP",
+      "name": "cics-plex",
+      "type": "string",
+    },
+  ],
+  "positionals": Array [
+    Object {
+      "description": "The name of the URIMAP to create. The maximum length of the program name is eight characters.",
+      "name": "urimapName",
+      "required": true,
+      "type": "string",
+    },
+    Object {
+      "description": "The CICS system definition (CSD) Group for the new transaction that you want to define. The maximum length of the group name is eight characters.",
+      "name": "csdGroup",
+      "required": true,
+      "type": "string",
+    },
+  ],
+  "profile": Object {
+    "optional": Array [
+      "cics",
+    ],
+  },
+  "type": "command",
+}
+`;

--- a/__tests__/cli/define/urimap-client/__snapshots__/UrimapClient.handler.unit.test.ts.snap
+++ b/__tests__/cli/define/urimap-client/__snapshots__/UrimapClient.handler.unit.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DefineUrimapClientHandler should call the defineUrimapClient api 1`] = `"The URIMAP '%s' was defined successfully."`;
+
+exports[`DefineUrimapClientHandler should call the defineUrimapClient api 2`] = `
+Object {
+  "response": Object {
+    "records": "testing",
+    "resultsummary": Object {
+      "api_response1": "1024",
+      "api_response2": "0",
+      "displayed_recordcount": "0",
+      "recordcount": "0",
+    },
+  },
+}
+`;

--- a/__tests__/cli/define/urimap-pipeline/UrimapPipeline.definition.unit.test.ts
+++ b/__tests__/cli/define/urimap-pipeline/UrimapPipeline.definition.unit.test.ts
@@ -11,14 +11,12 @@
 
 import { ICommandDefinition } from "@zowe/imperative";
 
-describe("cics define program", () => {
-    const DEFINE_RESOURCES = 5;
-
+describe("cics define urimap-pipeline", () => {
     it ("should not have changed", () => {
-        const definition: ICommandDefinition = require("../../../src/cli/define/Define.definition");
+        const path = "../../../../src/cli/define/urimap-pipeline/UrimapPipeline.definition";
+        const definition: ICommandDefinition = require(path).UrimapPipelineDefinition;
         expect(definition).toBeDefined();
-        expect(definition.children.length).toBe(DEFINE_RESOURCES);
-        delete definition.children;
+        delete definition.handler;
         expect(definition).toMatchSnapshot();
     });
 });

--- a/__tests__/cli/define/urimap-pipeline/UrimapPipeline.handler.unit.test.ts
+++ b/__tests__/cli/define/urimap-pipeline/UrimapPipeline.handler.unit.test.ts
@@ -1,0 +1,147 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { CommandProfiles, IHandlerParameters, IProfile, Session } from "@zowe/imperative";
+import { ICMCIApiResponse } from "../../../../src";
+import { UrimapPipelineDefinition } from "../../../../src/cli/define/urimap-pipeline/UrimapPipeline.definition";
+import UrimapPipelineHandler from "../../../../src/cli/define/urimap-pipeline/UrimapPipeline.handler";
+
+jest.mock("../../../../src/api/methods/define");
+const Define = require("../../../../src/api/methods/define");
+
+const host = "somewhere.com";
+const port = "43443";
+const user = "someone";
+const password = "somesecret";
+const protocol = "http";
+const rejectUnauthorized = false;
+
+const PROFILE_MAP = new Map<string, IProfile[]>();
+PROFILE_MAP.set(
+    "cics", [{
+        name: "cics",
+        type: "cics",
+        host,
+        port,
+        user,
+        password
+    }]
+);
+const PROFILES: CommandProfiles = new CommandProfiles(PROFILE_MAP);
+const DEFAULT_PARAMETERS: IHandlerParameters = {
+    arguments: {$0: "", _: []}, // Please provide arguments later on
+    response: {
+        data: {
+            setMessage: jest.fn((setMsgArgs) => {
+                expect(setMsgArgs).toMatchSnapshot();
+            }),
+            setObj: jest.fn((setObjArgs) => {
+                expect(setObjArgs).toMatchSnapshot();
+            }),
+            setExitCode: jest.fn()
+        },
+        console: {
+            log: jest.fn((logs) => {
+                expect(logs.toString()).toMatchSnapshot();
+            }),
+            error: jest.fn((errors) => {
+                expect(errors.toString()).toMatchSnapshot();
+            }),
+            errorHeader: jest.fn(() => undefined)
+        },
+        progress: {
+            startBar: jest.fn((parms) => undefined),
+            endBar: jest.fn(() => undefined)
+        },
+        format: {
+            output: jest.fn((parms) => {
+                expect(parms).toMatchSnapshot();
+            })
+        }
+    },
+    definition: UrimapPipelineDefinition,
+    fullDefinition: UrimapPipelineDefinition,
+    profiles: PROFILES
+};
+
+describe("DefineUrimapPipelineHandler", () => {
+    const pipelineName = "testPipeline";
+    const regionName = "testRegion";
+    const csdGroup = "testGroup";
+    const urimapName = "testUrimap";
+    const urimapHost = "testHost";
+    const urimapPath = "testPath";
+    const urimapScheme = "http";
+    const cicsPlex = "testPlex";
+
+    const defaultReturn: ICMCIApiResponse = {
+        response: {
+            resultsummary: {api_response1: "1024", api_response2: "0", recordcount: "0", displayed_recordcount: "0"},
+            records: "testing"
+        }
+    };
+
+    const functionSpy = jest.spyOn(Define, "defineUrimapPipeline");
+
+    beforeEach(() => {
+        functionSpy.mockClear();
+        functionSpy.mockImplementation(async () => defaultReturn);
+    });
+
+    it("should call the defineUrimapPipeline api", async () => {
+        const handler = new UrimapPipelineHandler();
+
+        const commandParameters = {...DEFAULT_PARAMETERS};
+        commandParameters.arguments = {
+            ...commandParameters.arguments,
+            urimapName,
+            csdGroup,
+            urimapPath,
+            urimapHost,
+            pipelineName,
+            urimapScheme,
+            regionName,
+            cicsPlex,
+            host,
+            port,
+            user,
+            password,
+            rejectUnauthorized,
+            protocol
+        };
+
+        await handler.process(commandParameters);
+
+        expect(functionSpy).toHaveBeenCalledTimes(1);
+        const testProfile = PROFILE_MAP.get("cics")[0];
+        expect(functionSpy).toHaveBeenCalledWith(
+            new Session({
+                type: "basic",
+                hostname: testProfile.host,
+                port: testProfile.port,
+                user: testProfile.user,
+                password: testProfile.password,
+                rejectUnauthorized,
+                protocol
+            }),
+            {
+                name: urimapName,
+                csdGroup,
+                path: urimapPath,
+                host: urimapHost,
+                pipelineName,
+                scheme: urimapScheme,
+                regionName,
+                cicsPlex
+            }
+        );
+    });
+});

--- a/__tests__/cli/define/urimap-pipeline/__snapshots__/UrimapPipeline.definition.unit.test.ts.snap
+++ b/__tests__/cli/define/urimap-pipeline/__snapshots__/UrimapPipeline.definition.unit.test.ts.snap
@@ -2,11 +2,13 @@
 
 exports[`cics define urimap-pipeline should not have changed 1`] = `
 Object {
-  "aliases": Array [],
+  "aliases": Array [
+    "up",
+  ],
   "description": "Define a new URIMAP of type pipeline to CICS. This processes incoming HTTP(S) requests",
   "examples": Array [
     Object {
-      "description": "Define a URIMAP named URIMAPA to the region named MYREGION in the CSD group MYGRP where the host is www.example.com and the path is /example/index.html",
+      "description": "Define a URIMAP named URIMAPA for the pipeline named PIPE123 to the region named MYREGION in the CSD group MYGRP where the host is www.example.com and the path is /example/index.html",
       "options": "URIMAPA MYGRP --urimap-path /example/index.html --urimap-host www.example.com --pipeline-name PIPE123 --region-name MYREGION",
     },
   ],

--- a/__tests__/cli/define/urimap-pipeline/__snapshots__/UrimapPipeline.definition.unit.test.ts.snap
+++ b/__tests__/cli/define/urimap-pipeline/__snapshots__/UrimapPipeline.definition.unit.test.ts.snap
@@ -1,0 +1,90 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cics define urimap-pipeline should not have changed 1`] = `
+Object {
+  "aliases": Array [],
+  "description": "Define a new URIMAP of type pipeline to CICS. This processes incoming HTTP(S) requests",
+  "examples": Array [
+    Object {
+      "description": "Define a URIMAP named URIMAPA to the region named MYREGION in the CSD group MYGRP where the host is www.example.com and the path is /example/index.html",
+      "options": "URIMAPA MYGRP --urimap-path /example/index.html --urimap-host www.example.com --pipeline-name PIPE123 --region-name MYREGION",
+    },
+  ],
+  "name": "urimap-pipeline",
+  "options": Array [
+    Object {
+      "aliases": Array [
+        "up",
+      ],
+      "description": "The path component of the URI",
+      "name": "urimap-path",
+      "required": true,
+      "type": "string",
+    },
+    Object {
+      "aliases": Array [
+        "uh",
+      ],
+      "description": "The host component of the URI",
+      "name": "urimap-host",
+      "required": true,
+      "type": "string",
+    },
+    Object {
+      "aliases": Array [
+        "us",
+      ],
+      "allowableValues": Object {
+        "caseSensitive": false,
+        "values": Array [
+          "http",
+          "https",
+        ],
+      },
+      "defaultValue": "http",
+      "description": "The scheme component to be used with the request (http or https)",
+      "name": "urimap-scheme",
+      "type": "string",
+    },
+    Object {
+      "aliases": Array [
+        "pn",
+      ],
+      "description": "The name of the PIPELINE resource definition for the web service. The maximum length of the pipeline name is eight characters",
+      "name": "pipeline-name",
+      "required": true,
+      "type": "string",
+    },
+    Object {
+      "description": "The CICS region name to which to define the new URIMAP",
+      "name": "region-name",
+      "type": "string",
+    },
+    Object {
+      "description": "The name of the CICSPlex to which to define the new URIMAP",
+      "name": "cics-plex",
+      "type": "string",
+    },
+  ],
+  "positionals": Array [
+    Object {
+      "description": "The name of the URIMAP to create. The maximum length of the program name is eight characters.",
+      "name": "urimapName",
+      "required": true,
+      "type": "string",
+    },
+    Object {
+      "description": "The CICS system definition (CSD) Group for the new transaction that you want to define. The maximum length of the group name is eight characters.",
+      "name": "csdGroup",
+      "required": true,
+      "type": "string",
+    },
+  ],
+  "profile": Object {
+    "optional": Array [
+      "cics",
+    ],
+  },
+  "type": "command",
+}
+`;

--- a/__tests__/cli/define/urimap-pipeline/__snapshots__/UrimapPipeline.handler.unit.test.ts.snap
+++ b/__tests__/cli/define/urimap-pipeline/__snapshots__/UrimapPipeline.handler.unit.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DefineUrimapPipelineHandler should call the defineUrimapPipeline api 1`] = `"The URIMAP '%s' was defined successfully."`;
+
+exports[`DefineUrimapPipelineHandler should call the defineUrimapPipeline api 2`] = `
+Object {
+  "response": Object {
+    "records": "testing",
+    "resultsummary": Object {
+      "api_response1": "1024",
+      "api_response2": "0",
+      "displayed_recordcount": "0",
+      "recordcount": "0",
+    },
+  },
+}
+`;

--- a/__tests__/cli/define/urimap-server/UrimapServer.definition.unit.test.ts
+++ b/__tests__/cli/define/urimap-server/UrimapServer.definition.unit.test.ts
@@ -11,14 +11,11 @@
 
 import { ICommandDefinition } from "@zowe/imperative";
 
-describe("cics define program", () => {
-    const DEFINE_RESOURCES = 5;
-
+describe("cics define urimap-server", () => {
     it ("should not have changed", () => {
-        const definition: ICommandDefinition = require("../../../src/cli/define/Define.definition");
+        const definition: ICommandDefinition = require("../../../../src/cli/define/urimap-server/UrimapServer.definition").UrimapServerDefinition;
         expect(definition).toBeDefined();
-        expect(definition.children.length).toBe(DEFINE_RESOURCES);
-        delete definition.children;
+        delete definition.handler;
         expect(definition).toMatchSnapshot();
     });
 });

--- a/__tests__/cli/define/urimap-server/UrimapServer.handler.unit.test.ts
+++ b/__tests__/cli/define/urimap-server/UrimapServer.handler.unit.test.ts
@@ -1,0 +1,147 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { CommandProfiles, IHandlerParameters, IProfile, Session } from "@zowe/imperative";
+import { ICMCIApiResponse } from "../../../../src";
+import { UrimapServerDefinition } from "../../../../src/cli/define/urimap-server/UrimapServer.definition";
+import UrimapServerHandler from "../../../../src/cli/define/urimap-server/UrimapServer.handler";
+
+jest.mock("../../../../src/api/methods/define");
+const Define = require("../../../../src/api/methods/define");
+
+const host = "somewhere.com";
+const port = "43443";
+const user = "someone";
+const password = "somesecret";
+const protocol = "http";
+const rejectUnauthorized = false;
+
+const PROFILE_MAP = new Map<string, IProfile[]>();
+PROFILE_MAP.set(
+    "cics", [{
+        name: "cics",
+        type: "cics",
+        host,
+        port,
+        user,
+        password
+    }]
+);
+const PROFILES: CommandProfiles = new CommandProfiles(PROFILE_MAP);
+const DEFAULT_PARAMETERS: IHandlerParameters = {
+    arguments: {$0: "", _: []}, // Please provide arguments later on
+    response: {
+        data: {
+            setMessage: jest.fn((setMsgArgs) => {
+                expect(setMsgArgs).toMatchSnapshot();
+            }),
+            setObj: jest.fn((setObjArgs) => {
+                expect(setObjArgs).toMatchSnapshot();
+            }),
+            setExitCode: jest.fn()
+        },
+        console: {
+            log: jest.fn((logs) => {
+                expect(logs.toString()).toMatchSnapshot();
+            }),
+            error: jest.fn((errors) => {
+                expect(errors.toString()).toMatchSnapshot();
+            }),
+            errorHeader: jest.fn(() => undefined)
+        },
+        progress: {
+            startBar: jest.fn((parms) => undefined),
+            endBar: jest.fn(() => undefined)
+        },
+        format: {
+            output: jest.fn((parms) => {
+                expect(parms).toMatchSnapshot();
+            })
+        }
+    },
+    definition: UrimapServerDefinition,
+    fullDefinition: UrimapServerDefinition,
+    profiles: PROFILES
+};
+
+describe("DefineUrimapServerHandler", () => {
+    const programName = "testProgram";
+    const regionName = "testRegion";
+    const csdGroup = "testGroup";
+    const urimapName = "testUrimap";
+    const urimapHost = "testHost";
+    const urimapPath = "testPath";
+    const urimapScheme = "http";
+    const cicsPlex = "testPlex";
+
+    const defaultReturn: ICMCIApiResponse = {
+        response: {
+            resultsummary: {api_response1: "1024", api_response2: "0", recordcount: "0", displayed_recordcount: "0"},
+            records: "testing"
+        }
+    };
+
+    const functionSpy = jest.spyOn(Define, "defineUrimapServer");
+
+    beforeEach(() => {
+        functionSpy.mockClear();
+        functionSpy.mockImplementation(async () => defaultReturn);
+    });
+
+    it("should call the defineUrimapServer api", async () => {
+        const handler = new UrimapServerHandler();
+
+        const commandParameters = {...DEFAULT_PARAMETERS};
+        commandParameters.arguments = {
+            ...commandParameters.arguments,
+            urimapName,
+            csdGroup,
+            urimapPath,
+            urimapHost,
+            programName,
+            urimapScheme,
+            regionName,
+            cicsPlex,
+            host,
+            port,
+            user,
+            password,
+            rejectUnauthorized,
+            protocol
+        };
+
+        await handler.process(commandParameters);
+
+        expect(functionSpy).toHaveBeenCalledTimes(1);
+        const testProfile = PROFILE_MAP.get("cics")[0];
+        expect(functionSpy).toHaveBeenCalledWith(
+            new Session({
+                type: "basic",
+                hostname: testProfile.host,
+                port: testProfile.port,
+                user: testProfile.user,
+                password: testProfile.password,
+                rejectUnauthorized,
+                protocol
+            }),
+            {
+                name: urimapName,
+                csdGroup,
+                path: urimapPath,
+                host: urimapHost,
+                programName,
+                scheme: urimapScheme,
+                regionName,
+                cicsPlex
+            }
+        );
+    });
+});

--- a/__tests__/cli/define/urimap-server/__snapshots__/UrimapServer.definition.unit.test.ts.snap
+++ b/__tests__/cli/define/urimap-server/__snapshots__/UrimapServer.definition.unit.test.ts.snap
@@ -1,0 +1,90 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cics define urimap-server should not have changed 1`] = `
+Object {
+  "aliases": Array [],
+  "description": "Define a new URIMAP of type server to CICS. This acts as an HTTP(S) server",
+  "examples": Array [
+    Object {
+      "description": "Define a URIMAP named URIMAPA for the program named PGM123 to the region named MYREGION in the CSD group MYGRP where the host is www.example.com and the path is /example/index.html",
+      "options": "URIMAPA MYGRP --urimap-path /example/index.html --urimap-host www.example.com --program-name PGM123 --region-name MYREGION",
+    },
+  ],
+  "name": "urimap-server",
+  "options": Array [
+    Object {
+      "aliases": Array [
+        "up",
+      ],
+      "description": "The path component of the URI",
+      "name": "urimap-path",
+      "required": true,
+      "type": "string",
+    },
+    Object {
+      "aliases": Array [
+        "uh",
+      ],
+      "description": "The host component of the URI",
+      "name": "urimap-host",
+      "required": true,
+      "type": "string",
+    },
+    Object {
+      "aliases": Array [
+        "us",
+      ],
+      "allowableValues": Object {
+        "caseSensitive": false,
+        "values": Array [
+          "http",
+          "https",
+        ],
+      },
+      "defaultValue": "http",
+      "description": "The scheme component to be used with the request (http or https)",
+      "name": "urimap-scheme",
+      "type": "string",
+    },
+    Object {
+      "aliases": Array [
+        "pn",
+      ],
+      "description": "The application program that makes or handles the requests",
+      "name": "program-name",
+      "required": true,
+      "type": "string",
+    },
+    Object {
+      "description": "The CICS region name to which to define the new URIMAP",
+      "name": "region-name",
+      "type": "string",
+    },
+    Object {
+      "description": "The name of the CICSPlex to which to define the new URIMAP",
+      "name": "cics-plex",
+      "type": "string",
+    },
+  ],
+  "positionals": Array [
+    Object {
+      "description": "The name of the URIMAP to create. The maximum length of the program name is eight characters.",
+      "name": "urimapName",
+      "required": true,
+      "type": "string",
+    },
+    Object {
+      "description": "The CICS system definition (CSD) Group for the new transaction that you want to define. The maximum length of the group name is eight characters.",
+      "name": "csdGroup",
+      "required": true,
+      "type": "string",
+    },
+  ],
+  "profile": Object {
+    "optional": Array [
+      "cics",
+    ],
+  },
+  "type": "command",
+}
+`;

--- a/__tests__/cli/define/urimap-server/__snapshots__/UrimapServer.definition.unit.test.ts.snap
+++ b/__tests__/cli/define/urimap-server/__snapshots__/UrimapServer.definition.unit.test.ts.snap
@@ -2,7 +2,9 @@
 
 exports[`cics define urimap-server should not have changed 1`] = `
 Object {
-  "aliases": Array [],
+  "aliases": Array [
+    "us",
+  ],
   "description": "Define a new URIMAP of type server to CICS. This acts as an HTTP(S) server",
   "examples": Array [
     Object {

--- a/__tests__/cli/define/urimap-server/__snapshots__/UrimapServer.handler.unit.test.ts.snap
+++ b/__tests__/cli/define/urimap-server/__snapshots__/UrimapServer.handler.unit.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DefineUrimapServerHandler should call the defineUrimapServer api 1`] = `"The URIMAP '%s' was defined successfully."`;
+
+exports[`DefineUrimapServerHandler should call the defineUrimapServer api 2`] = `
+Object {
+  "response": Object {
+    "records": "testing",
+    "resultsummary": Object {
+      "api_response1": "1024",
+      "api_response2": "0",
+      "displayed_recordcount": "0",
+      "recordcount": "0",
+    },
+  },
+}
+`;

--- a/__tests__/cli/get/resource/__snapshots__/Resource.definition.unit.test.ts.snap
+++ b/__tests__/cli/get/resource/__snapshots__/Resource.definition.unit.test.ts.snap
@@ -28,6 +28,10 @@ Object {
       "options": "CICSDefinitionTransaction --region-name MYREGION --parameter \\"CSDGROUP(GRP1)\\"",
     },
     Object {
+      "description": "Get URIMap definition resources from the CSD group named GRP1 and the region named MYREGION",
+      "options": "CICSDefinitionURIMap --region-name MYREGION --parameter \\"CSDGROUP(GRP1)\\"",
+    },
+    Object {
       "description": "Get program resources that start with the name PRG from the region named MYREGION",
       "options": "CICSProgram --region-name MYREGION --criteria \\"PROGRAM=PRG*\\"",
     },

--- a/src/api/constants/CicsCmci.constants.ts
+++ b/src/api/constants/CicsCmci.constants.ts
@@ -39,6 +39,11 @@ export const CicsCmciConstants: { [key: string]: any } = {
     CICS_PROGRAM_RESOURCE: "CICSProgram",
 
     /**
+     * Specifies the required part of the REST interface URI to access URIMap definitions
+     */
+    CICS_DEFINITION_URIMAP: "CICSDefinitionURIMap",
+
+    /**
      * ORDERBY parameter
      */
     ORDER_BY: "ORDERBY",

--- a/src/api/doc/IURIMapParms.ts
+++ b/src/api/doc/IURIMapParms.ts
@@ -23,28 +23,34 @@ export interface IURIMapParms {
     csdGroup: string;
 
     /**
-     * The path of the URIMap
+     * Path component of URI to which the map applies
      * Up to 255 characters long
      */
     path: string;
 
     /**
-     * The host of the URIMap
+     * Host component of URI to which the map applies
      * Up to 116 characters long
      */
     host: string;
 
     /**
-     * The program name of the URIMap
-     * Up to 8 characters long
-     */
-    programName: string;
-
-    /**
-     * The scheme of the URIMap
+     * Scheme component of URI to which the map applies
      * Allowed values: http, https
      */
     scheme: string;
+
+    /**
+     * Application program that will process the request
+     * Only used for server URIMaps; up to 8 characters long
+     */
+    programName?: string;
+
+    /**
+     * Pipeline that will process the request
+     * Only used for pipeline URIMaps; up to 8 characters long
+     */
+    pipelineName?: string;
 
     /**
      * The name of the CICS region of the URIMap

--- a/src/api/doc/IURIMapParms.ts
+++ b/src/api/doc/IURIMapParms.ts
@@ -26,19 +26,19 @@ export interface IURIMapParms {
      * Path component of URI to which the map applies
      * Up to 255 characters long
      */
-    path: string;
+    path?: string;
 
     /**
      * Host component of URI to which the map applies
      * Up to 116 characters long
      */
-    host: string;
+    host?: string;
 
     /**
      * Scheme component of URI to which the map applies
      * Allowed values: http, https
      */
-    scheme: string;
+    scheme?: string;
 
     /**
      * Application program that will process the request

--- a/src/api/doc/IURIMapParms.ts
+++ b/src/api/doc/IURIMapParms.ts
@@ -1,0 +1,58 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+export interface IURIMapParms {
+    /**
+     * The name of the URIMap
+     * Up to eight characters long
+     */
+    name: string;
+
+    /**
+     * CSD group for the URIMap
+     * Up to eight characters long
+     */
+    csdGroup: string;
+
+    /**
+     * The path of the URIMap
+     * Up to 255 characters long
+     */
+    path: string;
+
+    /**
+     * The host of the URIMap
+     * Up to 116 characters long
+     */
+    host: string;
+
+    /**
+     * The program name of the URIMap
+     * Up to 8 characters long
+     */
+    programName: string;
+
+    /**
+     * The scheme of the URIMap
+     * Allowed values: http, https
+     */
+    scheme: string;
+
+    /**
+     * The name of the CICS region of the URIMap
+     */
+    regionName: string;
+
+    /**
+     * CICS Plex of the URIMap
+     */
+    cicsPlex?: string;
+}

--- a/src/api/doc/index.ts
+++ b/src/api/doc/index.ts
@@ -14,3 +14,4 @@ export * from "./ICMCIResponseResultSummary";
 export * from "./IProgramParms";
 export * from "./IResourceParms";
 export * from "./ITransactionParms";
+export * from "./IURIMapParms";

--- a/src/api/methods/define/Define.ts
+++ b/src/api/methods/define/Define.ts
@@ -12,7 +12,7 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
-import { ICMCIApiResponse, IProgramParms, ITransactionParms } from "../../doc";
+import { ICMCIApiResponse, IProgramParms, ITransactionParms, IURIMapParms } from "../../doc";
 
 /**
  * Define a new program resource to CICS through CMCI REST API
@@ -100,3 +100,148 @@ export async function defineTransaction(session: AbstractSession, parms: ITransa
     return CicsCmciRestClient.postExpectParsedXml(session, cmciResource,
         [], requestBody) as any;
 }
+
+/**
+ * Define a new server URIMap to CICS through CMCI REST API
+ * @param {AbstractSession} session - the session to connect to CMCI with
+ * @param {IURIMapParms} parms - parameters for defining your URIMap
+ * @returns {Promise<any>} promise that resolves to the response (XML parsed into a javascript object)
+ *                          when the request is complete
+ * @throws {ImperativeError} CICS URIMap name not defined or blank
+ * @throws {ImperativeError} CICS CSD group not defined or blank
+ * @throws {ImperativeError} CICS URIMap path not defined or blank
+ * @throws {ImperativeError} CICS URIMap host not defined or blank
+ * @throws {ImperativeError} CICS URIMap program name not defined or blank
+ * @throws {ImperativeError} CICS URIMap scheme not defined or blank
+ * @throws {ImperativeError} CICS region name not defined or blank
+ * @throws {ImperativeError} CicsCmciRestClient request fails
+ */
+export async function defineUrimapServer(session: AbstractSession, parms: IURIMapParms): Promise<ICMCIApiResponse> {
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.name, "CICS URIMap name", "CICS URImap name is required");
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.csdGroup, "CICS CSD Group", "CICS CSD group is required");
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.path, "CICS URIMap Path", "CICS URIMap path is required");
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.host, "CICS URIMap Host", "CICS URIMap host is required");
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.programName, "CICS URIMap Program Name", "CICS URIMap program name is required");
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.scheme, "CICS URIMap Scheme", "CICS URIMap scheme is required");
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.regionName, "CICS Region name", "CICS region name is required");
+
+    Logger.getAppLogger().debug("Attempting to define a URIMap with the following parameters:\n%s", JSON.stringify(parms));
+    const requestBody: any = {
+        request: {
+            create: {
+                parameter: {
+                    $: {
+                        name: "CSD",
+                    }
+                },
+                attributes: {
+                    $: {
+                        name: parms.name,
+                        csdgroup: parms.csdGroup,
+                        path: parms.path,
+                        host: parms.host,
+                        program: parms.programName,
+                        scheme: parms.scheme
+                    }
+                }
+            }
+        }
+    };
+
+    const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
+    const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+        CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex + parms.regionName;
+    return CicsCmciRestClient.postExpectParsedXml(session, cmciResource, [], requestBody) as any;
+}
+
+// /**
+//  * Define a new transaction resource to CICS through CMCI REST API
+//  * @param {AbstractSession} session - the session to connect to CMCI with
+//  * @param {ITransactionParms} parms - parameters for defining your transaction
+//  * @returns {Promise<any>} promise that resolves to the response (XML parsed into a javascript object)
+//  *                          when the request is complete
+//  * @throws {ImperativeError} CICS transaction name not defined or blank
+//  * @throws {ImperativeError} CICS program name not defined or blank
+//  * @throws {ImperativeError} CICS CSD group not defined or blank
+//  * @throws {ImperativeError} CICS region name not defined or blank
+//  * @throws {ImperativeError} CicsCmciRestClient request fails
+//  */
+// export async function defineTransaction(session: AbstractSession, parms: ITransactionParms): Promise<ICMCIApiResponse> {
+//     ImperativeExpect.toBeDefinedAndNonBlank(parms.name, "CICS Transaction name", "CICS transaction name is required");
+//     ImperativeExpect.toBeDefinedAndNonBlank(parms.programName, "CICS Program name", "CICS program name is required");
+//     ImperativeExpect.toBeDefinedAndNonBlank(parms.csdGroup, "CICS CSD Group", "CICS CSD group is required");
+//     ImperativeExpect.toBeDefinedAndNonBlank(parms.regionName, "CICS Region name", "CICS region name is required");
+
+//     Logger.getAppLogger().debug("Attempting to define a transaction with the following parameters:\n%s", JSON.stringify(parms));
+//     const requestBody: any = {
+//         request: {
+//             create: {
+//                 parameter: {
+//                     $: {
+//                         name: "CSD",
+//                     }
+//                 },
+//                 attributes: {
+//                     $: {
+//                         name: parms.name,
+//                         program: parms.programName,
+//                         csdgroup: parms.csdGroup
+//                     }
+//                 }
+//             }
+//         }
+//     };
+
+//     const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
+//     const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+//         CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "/" + cicsPlex +
+//         parms.regionName;
+//     return CicsCmciRestClient.postExpectParsedXml(session, cmciResource,
+//         [], requestBody) as any;
+// }
+
+// /**
+//  * Define a new transaction resource to CICS through CMCI REST API
+//  * @param {AbstractSession} session - the session to connect to CMCI with
+//  * @param {ITransactionParms} parms - parameters for defining your transaction
+//  * @returns {Promise<any>} promise that resolves to the response (XML parsed into a javascript object)
+//  *                          when the request is complete
+//  * @throws {ImperativeError} CICS transaction name not defined or blank
+//  * @throws {ImperativeError} CICS program name not defined or blank
+//  * @throws {ImperativeError} CICS CSD group not defined or blank
+//  * @throws {ImperativeError} CICS region name not defined or blank
+//  * @throws {ImperativeError} CicsCmciRestClient request fails
+//  */
+// export async function defineTransaction(session: AbstractSession, parms: ITransactionParms): Promise<ICMCIApiResponse> {
+//     ImperativeExpect.toBeDefinedAndNonBlank(parms.name, "CICS Transaction name", "CICS transaction name is required");
+//     ImperativeExpect.toBeDefinedAndNonBlank(parms.programName, "CICS Program name", "CICS program name is required");
+//     ImperativeExpect.toBeDefinedAndNonBlank(parms.csdGroup, "CICS CSD Group", "CICS CSD group is required");
+//     ImperativeExpect.toBeDefinedAndNonBlank(parms.regionName, "CICS Region name", "CICS region name is required");
+
+//     Logger.getAppLogger().debug("Attempting to define a transaction with the following parameters:\n%s", JSON.stringify(parms));
+//     const requestBody: any = {
+//         request: {
+//             create: {
+//                 parameter: {
+//                     $: {
+//                         name: "CSD",
+//                     }
+//                 },
+//                 attributes: {
+//                     $: {
+//                         name: parms.name,
+//                         program: parms.programName,
+//                         csdgroup: parms.csdGroup
+//                     }
+//                 }
+//             }
+//         }
+//     };
+
+//     const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
+//     const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+//         CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "/" + cicsPlex +
+//         parms.regionName;
+//     return CicsCmciRestClient.postExpectParsedXml(session, cmciResource,
+//         [], requestBody) as any;
+// }

--- a/src/api/methods/define/Define.ts
+++ b/src/api/methods/define/Define.ts
@@ -196,7 +196,7 @@ export async function defineUrimapPipeline(session: AbstractSession, parms: IURI
  * @throws {ImperativeError} CICS region name not defined or blank
  */
 function validateUrimapParms(parms: IURIMapParms) {
-    ImperativeExpect.toBeDefinedAndNonBlank(parms.name, "CICS URIMap name", "CICS URIMap name is required");
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.name, "CICS URIMap Name", "CICS URIMap name is required");
     ImperativeExpect.toBeDefinedAndNonBlank(parms.csdGroup, "CICS CSD Group", "CICS CSD group is required");
     ImperativeExpect.toBeDefinedAndNonBlank(parms.path, "CICS URIMap Path", "CICS URIMap path is required");
     ImperativeExpect.toBeDefinedAndNonBlank(parms.host, "CICS URIMap Host", "CICS URIMap host is required");

--- a/src/api/methods/define/Define.ts
+++ b/src/api/methods/define/Define.ts
@@ -102,7 +102,7 @@ export async function defineTransaction(session: AbstractSession, parms: ITransa
 }
 
 /**
- * Define a new server URIMap to CICS through CMCI REST API
+ * Define a new server URIMap resource to CICS through CMCI REST API
  * @param {AbstractSession} session - the session to connect to CMCI with
  * @param {IURIMapParms} parms - parameters for defining your URIMap
  * @returns {Promise<any>} promise that resolves to the response (XML parsed into a javascript object)
@@ -111,22 +111,106 @@ export async function defineTransaction(session: AbstractSession, parms: ITransa
  * @throws {ImperativeError} CICS CSD group not defined or blank
  * @throws {ImperativeError} CICS URIMap path not defined or blank
  * @throws {ImperativeError} CICS URIMap host not defined or blank
+ * @throws {ImperativeError} CICS URIMap scheme not defined or blank
+ * @throws {ImperativeError} CICS region name not defined or blank
  * @throws {ImperativeError} CICS URIMap program name not defined or blank
+ * @throws {ImperativeError} CicsCmciRestClient request fails
+ */
+export async function defineUrimapServer(session: AbstractSession, parms: IURIMapParms): Promise<ICMCIApiResponse> {
+    validateUrimapParms(parms);
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.programName, "CICS URIMap Program name", "CICS URIMap program name is required");
+
+    Logger.getAppLogger().debug("Attempting to define a server URIMap with the following parameters:\n%s", JSON.stringify(parms));
+    const requestBody: any = buildUrimapRequestBody(parms, "server");
+    requestBody.request.create.attributes.$.program = parms.programName;
+
+    const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
+    const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+        CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex + parms.regionName;
+    return CicsCmciRestClient.postExpectParsedXml(session, cmciResource, [], requestBody) as any;
+}
+
+/**
+ * Define a new client URIMap resource to CICS through CMCI REST API
+ * @param {AbstractSession} session - the session to connect to CMCI with
+ * @param {IURIMapParms} parms - parameters for defining your URIMap
+ * @returns {Promise<any>} promise that resolves to the response (XML parsed into a javascript object)
+ *                          when the request is complete
+ * @throws {ImperativeError} CICS URIMap name not defined or blank
+ * @throws {ImperativeError} CICS CSD group not defined or blank
+ * @throws {ImperativeError} CICS URIMap path not defined or blank
+ * @throws {ImperativeError} CICS URIMap host not defined or blank
  * @throws {ImperativeError} CICS URIMap scheme not defined or blank
  * @throws {ImperativeError} CICS region name not defined or blank
  * @throws {ImperativeError} CicsCmciRestClient request fails
  */
-export async function defineUrimapServer(session: AbstractSession, parms: IURIMapParms): Promise<ICMCIApiResponse> {
-    ImperativeExpect.toBeDefinedAndNonBlank(parms.name, "CICS URIMap name", "CICS URImap name is required");
+export async function defineUrimapClient(session: AbstractSession, parms: IURIMapParms): Promise<ICMCIApiResponse> {
+    validateUrimapParms(parms);
+
+    Logger.getAppLogger().debug("Attempting to define a client URIMap with the following parameters:\n%s", JSON.stringify(parms));
+    const requestBody: any = buildUrimapRequestBody(parms, "client");
+
+    const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
+    const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+        CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex + parms.regionName;
+    return CicsCmciRestClient.postExpectParsedXml(session, cmciResource, [], requestBody) as any;
+}
+
+/**
+ * Define a new pipeline URIMap resource to CICS through CMCI REST API
+ * @param {AbstractSession} session - the session to connect to CMCI with
+ * @param {IURIMapParms} parms - parameters for defining your URIMap
+ * @returns {Promise<any>} promise that resolves to the response (XML parsed into a javascript object)
+ *                          when the request is complete
+ * @throws {ImperativeError} CICS URIMap name not defined or blank
+ * @throws {ImperativeError} CICS CSD group not defined or blank
+ * @throws {ImperativeError} CICS URIMap path not defined or blank
+ * @throws {ImperativeError} CICS URIMap host not defined or blank
+ * @throws {ImperativeError} CICS URIMap scheme not defined or blank
+ * @throws {ImperativeError} CICS region name not defined or blank
+ * @throws {ImperativeError} CICS URIMap pipeline name not defined or blank
+ * @throws {ImperativeError} CicsCmciRestClient request fails
+ */
+export async function defineUrimapPipeline(session: AbstractSession, parms: IURIMapParms): Promise<ICMCIApiResponse> {
+    validateUrimapParms(parms);
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.pipelineName, "CICS URIMap Pipeline name", "CICS URIMap pipeline name is required");
+
+    Logger.getAppLogger().debug("Attempting to define a pipeline URIMap with the following parameters:\n%s", JSON.stringify(parms));
+    const requestBody: any = buildUrimapRequestBody(parms, "pipeline");
+    requestBody.request.create.attributes.$.pipeline = parms.pipelineName;
+
+    const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
+    const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+        CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex + parms.regionName;
+    return CicsCmciRestClient.postExpectParsedXml(session, cmciResource, [], requestBody) as any;
+}
+
+/**
+ * Validate parameters for defining a URIMap
+ * @param {IURIMapParms} parms - parameters to validate
+ * @throws {ImperativeError} CICS URIMap name not defined or blank
+ * @throws {ImperativeError} CICS CSD group not defined or blank
+ * @throws {ImperativeError} CICS URIMap path not defined or blank
+ * @throws {ImperativeError} CICS URIMap host not defined or blank
+ * @throws {ImperativeError} CICS URIMap scheme not defined or blank
+ * @throws {ImperativeError} CICS region name not defined or blank
+ */
+function validateUrimapParms(parms: IURIMapParms) {
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.name, "CICS URIMap name", "CICS URIMap name is required");
     ImperativeExpect.toBeDefinedAndNonBlank(parms.csdGroup, "CICS CSD Group", "CICS CSD group is required");
     ImperativeExpect.toBeDefinedAndNonBlank(parms.path, "CICS URIMap Path", "CICS URIMap path is required");
     ImperativeExpect.toBeDefinedAndNonBlank(parms.host, "CICS URIMap Host", "CICS URIMap host is required");
-    ImperativeExpect.toBeDefinedAndNonBlank(parms.programName, "CICS URIMap Program Name", "CICS URIMap program name is required");
     ImperativeExpect.toBeDefinedAndNonBlank(parms.scheme, "CICS URIMap Scheme", "CICS URIMap scheme is required");
     ImperativeExpect.toBeDefinedAndNonBlank(parms.regionName, "CICS Region name", "CICS region name is required");
+}
 
-    Logger.getAppLogger().debug("Attempting to define a URIMap with the following parameters:\n%s", JSON.stringify(parms));
-    const requestBody: any = {
+/**
+ * Build request body for defining a URIMap
+ * @param {IURIMapParms} parms - parameters containing attribute values
+ * @param {string} usage - value of the usage attribute (server, client, or pipeline)
+ */
+function buildUrimapRequestBody(parms: IURIMapParms, usage: "server" | "client" | "pipeline") {
+    return {
         request: {
             create: {
                 parameter: {
@@ -140,108 +224,11 @@ export async function defineUrimapServer(session: AbstractSession, parms: IURIMa
                         csdgroup: parms.csdGroup,
                         path: parms.path,
                         host: parms.host,
-                        program: parms.programName,
-                        scheme: parms.scheme
+                        scheme: parms.scheme,
+                        usage
                     }
                 }
             }
         }
     };
-
-    const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-    const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex + parms.regionName;
-    return CicsCmciRestClient.postExpectParsedXml(session, cmciResource, [], requestBody) as any;
 }
-
-// /**
-//  * Define a new transaction resource to CICS through CMCI REST API
-//  * @param {AbstractSession} session - the session to connect to CMCI with
-//  * @param {ITransactionParms} parms - parameters for defining your transaction
-//  * @returns {Promise<any>} promise that resolves to the response (XML parsed into a javascript object)
-//  *                          when the request is complete
-//  * @throws {ImperativeError} CICS transaction name not defined or blank
-//  * @throws {ImperativeError} CICS program name not defined or blank
-//  * @throws {ImperativeError} CICS CSD group not defined or blank
-//  * @throws {ImperativeError} CICS region name not defined or blank
-//  * @throws {ImperativeError} CicsCmciRestClient request fails
-//  */
-// export async function defineTransaction(session: AbstractSession, parms: ITransactionParms): Promise<ICMCIApiResponse> {
-//     ImperativeExpect.toBeDefinedAndNonBlank(parms.name, "CICS Transaction name", "CICS transaction name is required");
-//     ImperativeExpect.toBeDefinedAndNonBlank(parms.programName, "CICS Program name", "CICS program name is required");
-//     ImperativeExpect.toBeDefinedAndNonBlank(parms.csdGroup, "CICS CSD Group", "CICS CSD group is required");
-//     ImperativeExpect.toBeDefinedAndNonBlank(parms.regionName, "CICS Region name", "CICS region name is required");
-
-//     Logger.getAppLogger().debug("Attempting to define a transaction with the following parameters:\n%s", JSON.stringify(parms));
-//     const requestBody: any = {
-//         request: {
-//             create: {
-//                 parameter: {
-//                     $: {
-//                         name: "CSD",
-//                     }
-//                 },
-//                 attributes: {
-//                     $: {
-//                         name: parms.name,
-//                         program: parms.programName,
-//                         csdgroup: parms.csdGroup
-//                     }
-//                 }
-//             }
-//         }
-//     };
-
-//     const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-//     const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-//         CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "/" + cicsPlex +
-//         parms.regionName;
-//     return CicsCmciRestClient.postExpectParsedXml(session, cmciResource,
-//         [], requestBody) as any;
-// }
-
-// /**
-//  * Define a new transaction resource to CICS through CMCI REST API
-//  * @param {AbstractSession} session - the session to connect to CMCI with
-//  * @param {ITransactionParms} parms - parameters for defining your transaction
-//  * @returns {Promise<any>} promise that resolves to the response (XML parsed into a javascript object)
-//  *                          when the request is complete
-//  * @throws {ImperativeError} CICS transaction name not defined or blank
-//  * @throws {ImperativeError} CICS program name not defined or blank
-//  * @throws {ImperativeError} CICS CSD group not defined or blank
-//  * @throws {ImperativeError} CICS region name not defined or blank
-//  * @throws {ImperativeError} CicsCmciRestClient request fails
-//  */
-// export async function defineTransaction(session: AbstractSession, parms: ITransactionParms): Promise<ICMCIApiResponse> {
-//     ImperativeExpect.toBeDefinedAndNonBlank(parms.name, "CICS Transaction name", "CICS transaction name is required");
-//     ImperativeExpect.toBeDefinedAndNonBlank(parms.programName, "CICS Program name", "CICS program name is required");
-//     ImperativeExpect.toBeDefinedAndNonBlank(parms.csdGroup, "CICS CSD Group", "CICS CSD group is required");
-//     ImperativeExpect.toBeDefinedAndNonBlank(parms.regionName, "CICS Region name", "CICS region name is required");
-
-//     Logger.getAppLogger().debug("Attempting to define a transaction with the following parameters:\n%s", JSON.stringify(parms));
-//     const requestBody: any = {
-//         request: {
-//             create: {
-//                 parameter: {
-//                     $: {
-//                         name: "CSD",
-//                     }
-//                 },
-//                 attributes: {
-//                     $: {
-//                         name: parms.name,
-//                         program: parms.programName,
-//                         csdgroup: parms.csdGroup
-//                     }
-//                 }
-//             }
-//         }
-//     };
-
-//     const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-//     const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-//         CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "/" + cicsPlex +
-//         parms.regionName;
-//     return CicsCmciRestClient.postExpectParsedXml(session, cmciResource,
-//         [], requestBody) as any;
-// }

--- a/src/api/methods/delete/Delete.ts
+++ b/src/api/methods/delete/Delete.ts
@@ -12,7 +12,7 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
-import { ICMCIApiResponse, IProgramParms, ITransactionParms } from "../../doc";
+import { ICMCIApiResponse, IProgramParms, ITransactionParms, IURIMapParms } from "../../doc";
 
 /**
  * Delete a program installed in CICS through CMCI REST API
@@ -58,6 +58,31 @@ export async function deleteTransaction(session: AbstractSession, parms: ITransa
     const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
     const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
         CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "/" + cicsPlex +
+        `${parms.regionName}?CRITERIA=(NAME=${parms.name})&PARAMETER=CSDGROUP(${parms.csdGroup})`;
+    return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []);
+}
+
+/**
+ * Delete a URIMap installed in CICS through CMCI REST API
+ * @param {AbstractSession} session - the session to connect to CMCI with
+ * @param {IURIMapParms} parms - parameters for deleting your URIMap
+ * @returns {Promise<ICMCIApiResponse>} promise that resolves to the response (XML parsed into a javascript object)
+ *                          when the request is complete
+ * @throws {ImperativeError} CICS URIMap name not defined or blank
+ * @throws {ImperativeError} CICS CSD group not defined or blank
+ * @throws {ImperativeError} CICS region name not defined or blank
+ * @throws {ImperativeError} CicsCmciRestClient request fails
+ */
+export async function deleteUrimap(session: AbstractSession, parms: IURIMapParms): Promise<ICMCIApiResponse> {
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.name, "CICS URIMap name", "CICS URIMap name is required");
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.csdGroup, "CICS CSD Group", "CICS CSD group is required");
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.regionName, "CICS Region name", "CICS region name is required");
+
+    Logger.getAppLogger().debug("Attempting to delete a URIMap with the following parameters:\n%s", JSON.stringify(parms));
+
+    const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
+    const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+        CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex +
         `${parms.regionName}?CRITERIA=(NAME=${parms.name})&PARAMETER=CSDGROUP(${parms.csdGroup})`;
     return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []);
 }

--- a/src/cli/-strings-/en.ts
+++ b/src/cli/-strings-/en.ts
@@ -55,8 +55,12 @@ export default {
                         "in the CSD group MYGRP"
                 }
             },
-            URIMAPSERVER: {
-                DESCRIPTION: "Define a new URIMAP of type server to CICS. This acts as an HTTP(S) server",
+            URIMAP: {
+                DESCRIPTION: {
+                    SERVER: "Define a new URIMAP of type server to CICS. This acts as an HTTP(S) server",
+                    CLIENT: "Define a new URIMAP of type client to CICS. This acts as an HTTP(S) client",
+                    PIPELINE: "Define a new URIMAP of type pipeline to CICS. This processes incoming HTTP(S) requests"
+                },
                 POSITIONALS: {
                     URIMAPNAME: "The name of the URIMAP to create. The maximum length of the program name is eight characters.",
                     CSDGROUP: "The CICS system definition (CSD) Group for the new transaction that you want to define." +
@@ -66,9 +70,11 @@ export default {
                     URIMAPHOST: "The host component of the URI",
                     URIMAPPATH: "The path component of the URI",
                     URIMAPSCHEME: "The scheme component to be used with the request (http or https)",
-                    PROGRAMNAME: "The application program that makes or handles the requests",
                     REGIONNAME: "The CICS region name to which to define the new URIMAP",
-                    CICSPLEX: "The name of the CICSPlex to which to define the new URIMAP"
+                    CICSPLEX: "The name of the CICSPlex to which to define the new URIMAP",
+                    PROGRAMNAME: "The application program that makes or handles the requests",
+                    PIPELINENAME: "The name of the PIPELINE resource definition for the web service." +
+                        " The maximum length of the pipeline name is eight characters",
                 },
                 MESSAGES: {
                     SUCCESS: "The URIMAP '%s' was defined successfully."
@@ -76,52 +82,6 @@ export default {
                 EXAMPLES: {
                     EX1: "Define a URIMAP named URIMAPA for the program named PGM123 to the region named MYREGION " +
                        "in the CSD group MYGRP where the host is www.example.com and the path is /example/index.html"
-                }
-            },
-            URIMAPCLIENT: {
-                DESCRIPTION: "Define a new URIMAP of type client to CICS. This acts as an HTTP(S) client",
-                POSITIONALS: {
-                    URIMAPNAME: "The name of the URIMAP to create. The maximum length of the program name is eight characters.",
-                    CSDGROUP: "The CICS system definition (CSD) Group for the new transaction that you want to define." +
-                        " The maximum length of the group name is eight characters."
-                },
-                OPTIONS: {
-                    URIMAPHOST: "The host component of the URI",
-                    URIMAPPATH: "The path component of the URI",
-                    URIMAPSCHEME: "The scheme component to be used with the request (http or https)",
-                    REGIONNAME: "The CICS region name to which to define the new URIMAP",
-                    CICSPLEX: "The name of the CICSPlex to which to define the new URIMAP"
-                },
-                MESSAGES: {
-                    SUCCESS: "The URIMAP '%s' was defined successfully."
-                },
-                EXAMPLES: {
-                    EX1: "Define a URIMAP named URIMAPA to the region named MYREGION in the CSD group MYGRP " +
-                       "where the host is www.example.com and the path is /example/index.html"
-                }
-            },
-            URIMAPPIPELINE: {
-                DESCRIPTION: "Define a new URIMAP of type pipeline to CICS. This processes incoming HTTP(S) requests",
-                POSITIONALS: {
-                    URIMAPNAME: "The name of the URIMAP to create. The maximum length of the program name is eight characters.",
-                    CSDGROUP: "The CICS system definition (CSD) Group for the new transaction that you want to define." +
-                        " The maximum length of the group name is eight characters."
-                },
-                OPTIONS: {
-                    URIMAPHOST: "The host component of the URI",
-                    URIMAPPATH: "The path component of the URI",
-                    URIMAPSCHEME: "The scheme component to be used with the request (http or https)",
-                    PIPELINENAME: "The name of the PIPELINE resource definition for the web service." +
-                        " The maximum length of the pipeline name is eight characters",
-                    REGIONNAME: "The CICS region name to which to define the new URIMAP",
-                    CICSPLEX: "The name of the CICSPlex to which to define the new URIMAP"
-                },
-                MESSAGES: {
-                    SUCCESS: "The URIMAP '%s' was defined successfully."
-                },
-                EXAMPLES: {
-                    EX1: "Define a URIMAP named URIMAPA to the region named MYREGION in the CSD group MYGRP " +
-                       "where the host is www.example.com and the path is /example/index.html"
                 }
             }
         }
@@ -231,9 +191,10 @@ export default {
                     EX3: "Get local file resources from the region named MYREGION",
                     EX4: "Get program definition resources from the CSD group named GRP1 and the region named MYREGION",
                     EX5: "Get transaction definition resources from the CSD group named GRP1 and the region named MYREGION",
-                    EX6: "Get program resources that start with the name PRG from the region named MYREGION",
-                    EX7: "Get a local transaction resource named TRAN from the region named MYREGION",
-                    EX8: "Get program resources that start with the name MYPRG from the region named MYREGION and display various fields as a table",
+                    EX6: "Get URIMap definition resources from the CSD group named GRP1 and the region named MYREGION",
+                    EX7: "Get program resources that start with the name PRG from the region named MYREGION",
+                    EX8: "Get a local transaction resource named TRAN from the region named MYREGION",
+                    EX9: "Get program resources that start with the name MYPRG from the region named MYREGION and display various fields as a table",
                 }
             }
         }

--- a/src/cli/-strings-/en.ts
+++ b/src/cli/-strings-/en.ts
@@ -54,6 +54,75 @@ export default {
                     EX1: "Define a transaction named TRN1 for the program named PGM123 to the region named MYREGION " +
                         "in the CSD group MYGRP"
                 }
+            },
+            URIMAPSERVER: {
+                DESCRIPTION: "Define a new URIMAP of type server to CICS. This acts as an HTTP(S) server",
+                POSITIONALS: {
+                    URIMAPNAME: "The name of the URIMAP to create. The maximum length of the program name is eight characters.",
+                    CSDGROUP: "The CICS system definition (CSD) Group for the new transaction that you want to define." +
+                        " The maximum length of the group name is eight characters."
+                },
+                OPTIONS: {
+                    URIMAPHOST: "The host component of the URI",
+                    URIMAPPATH: "The path component of the URI",
+                    URIMAPSCHEME: "The scheme component to be used with the request (http or https)",
+                    PROGRAMNAME: "The application program that makes or handles the requests",
+                    REGIONNAME: "The CICS region name to which to define the new URIMAP",
+                    CICSPLEX: "The name of the CICSPlex to which to define the new URIMAP"
+                },
+                MESSAGES: {
+                    SUCCESS: "The URIMAP '%s' was defined successfully."
+                },
+                EXAMPLES: {
+                    EX1: "Define a URIMAP named URIMAPA for the program named PGM123 to the region named MYREGION " +
+                       "in the CSD group MYGRP where the host is www.example.com and the path is /example/index.html"
+                }
+            },
+            URIMAPCLIENT: {
+                DESCRIPTION: "Define a new URIMAP of type client to CICS. This acts as an HTTP(S) client",
+                POSITIONALS: {
+                    URIMAPNAME: "The name of the URIMAP to create. The maximum length of the program name is eight characters.",
+                    CSDGROUP: "The CICS system definition (CSD) Group for the new transaction that you want to define." +
+                        " The maximum length of the group name is eight characters."
+                },
+                OPTIONS: {
+                    URIMAPHOST: "The host component of the URI",
+                    URIMAPPATH: "The path component of the URI",
+                    URIMAPSCHEME: "The scheme component to be used with the request (http or https)",
+                    REGIONNAME: "The CICS region name to which to define the new URIMAP",
+                    CICSPLEX: "The name of the CICSPlex to which to define the new URIMAP"
+                },
+                MESSAGES: {
+                    SUCCESS: "The URIMAP '%s' was defined successfully."
+                },
+                EXAMPLES: {
+                    EX1: "Define a URIMAP named URIMAPA to the region named MYREGION in the CSD group MYGRP " +
+                       "where the host is www.example.com and the path is /example/index.html"
+                }
+            },
+            URIMAPPIPELINE: {
+                DESCRIPTION: "Define a new URIMAP of type pipeline to CICS. This processes incoming HTTP(S) requests",
+                POSITIONALS: {
+                    URIMAPNAME: "The name of the URIMAP to create. The maximum length of the program name is eight characters.",
+                    CSDGROUP: "The CICS system definition (CSD) Group for the new transaction that you want to define." +
+                        " The maximum length of the group name is eight characters."
+                },
+                OPTIONS: {
+                    URIMAPHOST: "The host component of the URI",
+                    URIMAPPATH: "The path component of the URI",
+                    URIMAPSCHEME: "The scheme component to be used with the request (http or https)",
+                    PIPELINENAME: "The name of the PIPELINE resource definition for the web service." +
+                        " The maximum length of the pipeline name is eight characters",
+                    REGIONNAME: "The CICS region name to which to define the new URIMAP",
+                    CICSPLEX: "The name of the CICSPlex to which to define the new URIMAP"
+                },
+                MESSAGES: {
+                    SUCCESS: "The URIMAP '%s' was defined successfully."
+                },
+                EXAMPLES: {
+                    EX1: "Define a URIMAP named URIMAPA to the region named MYREGION in the CSD group MYGRP " +
+                       "where the host is www.example.com and the path is /example/index.html"
+                }
             }
         }
     },

--- a/src/cli/-strings-/en.ts
+++ b/src/cli/-strings-/en.ts
@@ -80,8 +80,18 @@ export default {
                     SUCCESS: "The URIMAP '%s' was defined successfully."
                 },
                 EXAMPLES: {
-                    EX1: "Define a URIMAP named URIMAPA for the program named PGM123 to the region named MYREGION " +
-                       "in the CSD group MYGRP where the host is www.example.com and the path is /example/index.html"
+                    SERVER: {
+                        EX1: "Define a URIMAP named URIMAPA for the program named PGM123 to the region named MYREGION " +
+                            "in the CSD group MYGRP where the host is www.example.com and the path is /example/index.html"
+                    },
+                    CLIENT: {
+                        EX1: "Define a URIMAP named URIMAPA to the region named MYREGION in the CSD group MYGRP " +
+                            "where the host is www.example.com and the path is /example/index.html"
+                    },
+                    PIPELINE: {
+                        EX1: "Define a URIMAP named URIMAPA for the pipeline named PIPE123 to the region named MYREGION " +
+                            "in the CSD group MYGRP where the host is www.example.com and the path is /example/index.html"
+                    }
                 }
             }
         }

--- a/src/cli/define/Define.definition.ts
+++ b/src/cli/define/Define.definition.ts
@@ -16,6 +16,10 @@ import i18nTypings from "../-strings-/en";
 import { TransactionDefinition } from "./transaction/Transaction.definition";
 import { CicsSession } from "../CicsSession";
 
+import { UrimapServerDefinition } from "./urimap-server/UrimapServer.definition";
+import { UrimapClientDefinition } from "./urimap-client/UrimapClient.definition";
+import { UrimapPipelineDefinition } from "./urimap-pipeline/UrimapPipeline.definition";
+
 // Does not use the import in anticipation of some internationalization work to be done later.
 const strings = (require("../-strings-/en").default as typeof i18nTypings).DEFINE;
 
@@ -28,7 +32,10 @@ const definition: ICommandDefinition = {
     description: strings.DESCRIPTION,
     type: "group",
     children: [ProgramDefinition,
-               TransactionDefinition],
+               TransactionDefinition,
+               UrimapServerDefinition,
+               UrimapClientDefinition,
+               UrimapPipelineDefinition],
     passOn: [
         {
             property: "options",

--- a/src/cli/define/urimap-client/UrimapClient.definition.ts
+++ b/src/cli/define/urimap-client/UrimapClient.definition.ts
@@ -1,0 +1,73 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { ICommandDefinition } from "@zowe/imperative";
+
+import i18nTypings from "../../-strings-/en";
+
+// Does not use the import in anticipation of some internationalization work to be done later.
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.URIMAPCLIENT;
+
+export const UrimapClientDefinition: ICommandDefinition = {
+    name: "urimap-client", aliases: [],
+    description: strings.DESCRIPTION,
+    handler: __dirname + "/UrimapClient.handler",
+    type: "command",
+    positionals: [{
+        name: "urimapName",
+        description: strings.POSITIONALS.URIMAPNAME,
+        type: "string",
+        required: true
+    }, {
+        name: "csdGroup",
+        description: strings.POSITIONALS.CSDGROUP,
+        type: "string",
+        required: true
+    }],
+    options: [
+        {
+            name: "urimap-path",
+            aliases: ["up"],
+            description: strings.OPTIONS.URIMAPPATH,
+            type: "string",
+            required: true
+        },
+        {
+            name: "urimap-host",
+            aliases: ["uh"],
+            description: strings.OPTIONS.URIMAPHOST,
+            type: "string",
+            required: true
+        },
+        {
+            name: "urimap-scheme",
+            aliases: ["us"],
+            description: strings.OPTIONS.URIMAPSCHEME,
+            type: "string",
+            allowableValues: {values: ["http", "https"], caseSensitive: false},
+            defaultValue: "http"
+        },
+        {
+            name: "region-name",
+            description: strings.OPTIONS.REGIONNAME,
+            type: "string",
+        },
+        {
+            name: "cics-plex",
+            description: strings.OPTIONS.CICSPLEX,
+            type: "string"
+        }],
+    profile: {optional: ["cics"]},
+    examples: [{
+        description: strings.EXAMPLES.EX1,
+        options: "URIMAPA MYGRP --urimap-path /example/index.html --urimap-host www.example.com --region-name MYREGION"
+    }]
+};

--- a/src/cli/define/urimap-client/UrimapClient.definition.ts
+++ b/src/cli/define/urimap-client/UrimapClient.definition.ts
@@ -14,11 +14,11 @@ import { ICommandDefinition } from "@zowe/imperative";
 import i18nTypings from "../../-strings-/en";
 
 // Does not use the import in anticipation of some internationalization work to be done later.
-const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.URIMAPCLIENT;
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.URIMAP;
 
 export const UrimapClientDefinition: ICommandDefinition = {
     name: "urimap-client", aliases: [],
-    description: strings.DESCRIPTION,
+    description: strings.DESCRIPTION.CLIENT,
     handler: __dirname + "/UrimapClient.handler",
     type: "command",
     positionals: [{

--- a/src/cli/define/urimap-client/UrimapClient.definition.ts
+++ b/src/cli/define/urimap-client/UrimapClient.definition.ts
@@ -17,7 +17,8 @@ import i18nTypings from "../../-strings-/en";
 const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.URIMAP;
 
 export const UrimapClientDefinition: ICommandDefinition = {
-    name: "urimap-client", aliases: [],
+    name: "urimap-client",
+    aliases: ["uc"],
     description: strings.DESCRIPTION.CLIENT,
     handler: __dirname + "/UrimapClient.handler",
     type: "command",
@@ -67,7 +68,7 @@ export const UrimapClientDefinition: ICommandDefinition = {
         }],
     profile: {optional: ["cics"]},
     examples: [{
-        description: strings.EXAMPLES.EX1,
+        description: strings.EXAMPLES.CLIENT.EX1,
         options: "URIMAPA MYGRP --urimap-path /example/index.html --urimap-host www.example.com --region-name MYREGION"
     }]
 };

--- a/src/cli/define/urimap-client/UrimapClient.handler.ts
+++ b/src/cli/define/urimap-client/UrimapClient.handler.ts
@@ -1,0 +1,50 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { AbstractSession, ICommandHandler, IHandlerParameters, IProfile, ITaskWithStatus, TaskStage } from "@zowe/imperative";
+import { defineProgram, ICMCIApiResponse, defineUrimapServer } from "../../../api";
+import { CicsBaseHandler } from "../../CicsBaseHandler";
+
+import i18nTypings from "../../-strings-/en";
+
+// Does not use the import in anticipation of some internationalization work to be done later.
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.URIMAPCLIENT;
+
+/**
+ * Command handler for defining CICS URIMaps via CMCI
+ * @export
+ * @class ProgramHandler
+ * @implements {ICommandHandler}
+ */
+export default class UrimapClientHandler extends CicsBaseHandler {
+    public async processWithSession(params: IHandlerParameters, session: AbstractSession, profile: IProfile): Promise<ICMCIApiResponse> {
+
+        const status: ITaskWithStatus = {
+            statusMessage: "Defining URIMAP of type Client to CICS",
+            percentComplete: 0,
+            stageName: TaskStage.IN_PROGRESS
+        };
+        params.response.progress.startBar({task: status});
+
+        const response = await defineUrimapClient(session, {
+            name: params.arguments.urimapName,
+            csdGroup: params.arguments.csdGroup,
+            path: params.arguments.urimapPath,
+            host: params.arguments.urimapHost,
+            scheme: params.arguments.urimapScheme,
+            regionName: params.arguments.regionName || profile.regionName,
+            cicsPlex: params.arguments.cicsPlex || profile.cicsPlex
+        });
+
+        params.response.console.log(strings.MESSAGES.SUCCESS, params.arguments.programName);
+        return response;
+    }
+}

--- a/src/cli/define/urimap-client/UrimapClient.handler.ts
+++ b/src/cli/define/urimap-client/UrimapClient.handler.ts
@@ -16,7 +16,7 @@ import { CicsBaseHandler } from "../../CicsBaseHandler";
 import i18nTypings from "../../-strings-/en";
 
 // Does not use the import in anticipation of some internationalization work to be done later.
-const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.URIMAPCLIENT;
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.URIMAP;
 
 /**
  * Command handler for defining CICS URIMaps via CMCI

--- a/src/cli/define/urimap-client/UrimapClient.handler.ts
+++ b/src/cli/define/urimap-client/UrimapClient.handler.ts
@@ -10,7 +10,7 @@
 */
 
 import { AbstractSession, ICommandHandler, IHandlerParameters, IProfile, ITaskWithStatus, TaskStage } from "@zowe/imperative";
-import { defineProgram, ICMCIApiResponse, defineUrimapServer } from "../../../api";
+import { ICMCIApiResponse, defineUrimapClient } from "../../../api";
 import { CicsBaseHandler } from "../../CicsBaseHandler";
 
 import i18nTypings from "../../-strings-/en";
@@ -21,7 +21,7 @@ const strings = (require("../../-strings-/en").default as typeof i18nTypings).DE
 /**
  * Command handler for defining CICS URIMaps via CMCI
  * @export
- * @class ProgramHandler
+ * @class UrimapClientHandler
  * @implements {ICommandHandler}
  */
 export default class UrimapClientHandler extends CicsBaseHandler {
@@ -44,7 +44,7 @@ export default class UrimapClientHandler extends CicsBaseHandler {
             cicsPlex: params.arguments.cicsPlex || profile.cicsPlex
         });
 
-        params.response.console.log(strings.MESSAGES.SUCCESS, params.arguments.programName);
+        params.response.console.log(strings.MESSAGES.SUCCESS, params.arguments.urimapName);
         return response;
     }
 }

--- a/src/cli/define/urimap-pipeline/UrimapPipeline.definition.ts
+++ b/src/cli/define/urimap-pipeline/UrimapPipeline.definition.ts
@@ -1,0 +1,80 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { ICommandDefinition } from "@zowe/imperative";
+
+import i18nTypings from "../../-strings-/en";
+
+// Does not use the import in anticipation of some internationalization work to be done later.
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.URIMAPPIPELINE;
+
+export const UrimapPipelineDefinition: ICommandDefinition = {
+    name: "urimap-pipeline", aliases: [],
+    description: strings.DESCRIPTION,
+    handler: __dirname + "/UrimapPipeline.handler",
+    type: "command",
+    positionals: [{
+        name: "urimapName",
+        description: strings.POSITIONALS.URIMAPNAME,
+        type: "string",
+        required: true
+    }, {
+        name: "csdGroup",
+        description: strings.POSITIONALS.CSDGROUP,
+        type: "string",
+        required: true
+    }],
+    options: [
+        {
+            name: "urimap-path",
+            aliases: ["up"],
+            description: strings.OPTIONS.URIMAPPATH,
+            type: "string",
+            required: true
+        },
+        {
+            name: "urimap-host",
+            aliases: ["uh"],
+            description: strings.OPTIONS.URIMAPHOST,
+            type: "string",
+            required: true
+        },
+        {
+            name: "urimap-scheme",
+            aliases: ["us"],
+            description: strings.OPTIONS.URIMAPSCHEME,
+            type: "string",
+            allowableValues: {values: ["http", "https"], caseSensitive: false},
+            defaultValue: "http"
+        },
+        {
+            name: "pipeline-name",
+            aliases: ["pn"],
+            description: strings.OPTIONS.PIPELINENAME,
+            type: "string",
+            required: true
+        },
+        {
+            name: "region-name",
+            description: strings.OPTIONS.REGIONNAME,
+            type: "string",
+        },
+        {
+            name: "cics-plex",
+            description: strings.OPTIONS.CICSPLEX,
+            type: "string"
+        }],
+    profile: {optional: ["cics"]},
+    examples: [{
+        description: strings.EXAMPLES.EX1,
+        options: "URIMAPA MYGRP --urimap-path /example/index.html --urimap-host www.example.com --pipeline-name PIPE123 --region-name MYREGION"
+    }]
+};

--- a/src/cli/define/urimap-pipeline/UrimapPipeline.definition.ts
+++ b/src/cli/define/urimap-pipeline/UrimapPipeline.definition.ts
@@ -17,7 +17,8 @@ import i18nTypings from "../../-strings-/en";
 const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.URIMAP;
 
 export const UrimapPipelineDefinition: ICommandDefinition = {
-    name: "urimap-pipeline", aliases: [],
+    name: "urimap-pipeline",
+    aliases: ["up"],
     description: strings.DESCRIPTION.PIPELINE,
     handler: __dirname + "/UrimapPipeline.handler",
     type: "command",
@@ -74,7 +75,7 @@ export const UrimapPipelineDefinition: ICommandDefinition = {
         }],
     profile: {optional: ["cics"]},
     examples: [{
-        description: strings.EXAMPLES.EX1,
+        description: strings.EXAMPLES.PIPELINE.EX1,
         options: "URIMAPA MYGRP --urimap-path /example/index.html --urimap-host www.example.com --pipeline-name PIPE123 --region-name MYREGION"
     }]
 };

--- a/src/cli/define/urimap-pipeline/UrimapPipeline.definition.ts
+++ b/src/cli/define/urimap-pipeline/UrimapPipeline.definition.ts
@@ -14,11 +14,11 @@ import { ICommandDefinition } from "@zowe/imperative";
 import i18nTypings from "../../-strings-/en";
 
 // Does not use the import in anticipation of some internationalization work to be done later.
-const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.URIMAPPIPELINE;
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.URIMAP;
 
 export const UrimapPipelineDefinition: ICommandDefinition = {
     name: "urimap-pipeline", aliases: [],
-    description: strings.DESCRIPTION,
+    description: strings.DESCRIPTION.PIPELINE,
     handler: __dirname + "/UrimapPipeline.handler",
     type: "command",
     positionals: [{

--- a/src/cli/define/urimap-pipeline/UrimapPipeline.handler.ts
+++ b/src/cli/define/urimap-pipeline/UrimapPipeline.handler.ts
@@ -16,7 +16,7 @@ import { CicsBaseHandler } from "../../CicsBaseHandler";
 import i18nTypings from "../../-strings-/en";
 
 // Does not use the import in anticipation of some internationalization work to be done later.
-const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.URIMAPPIPELINE;
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.URIMAP;
 
 /**
  * Command handler for defining CICS URIMaps via CMCI

--- a/src/cli/define/urimap-pipeline/UrimapPipeline.handler.ts
+++ b/src/cli/define/urimap-pipeline/UrimapPipeline.handler.ts
@@ -10,7 +10,7 @@
 */
 
 import { AbstractSession, ICommandHandler, IHandlerParameters, IProfile, ITaskWithStatus, TaskStage } from "@zowe/imperative";
-import { defineProgram, ICMCIApiResponse, defineUrimapServer } from "../../../api";
+import { ICMCIApiResponse, defineUrimapPipeline } from "../../../api";
 import { CicsBaseHandler } from "../../CicsBaseHandler";
 
 import i18nTypings from "../../-strings-/en";
@@ -21,7 +21,7 @@ const strings = (require("../../-strings-/en").default as typeof i18nTypings).DE
 /**
  * Command handler for defining CICS URIMaps via CMCI
  * @export
- * @class ProgramHandler
+ * @class UrimapPipelineHandler
  * @implements {ICommandHandler}
  */
 export default class UrimapPipelineHandler extends CicsBaseHandler {
@@ -45,7 +45,7 @@ export default class UrimapPipelineHandler extends CicsBaseHandler {
             cicsPlex: params.arguments.cicsPlex || profile.cicsPlex
         });
 
-        params.response.console.log(strings.MESSAGES.SUCCESS, params.arguments.programName);
+        params.response.console.log(strings.MESSAGES.SUCCESS, params.arguments.urimapName);
         return response;
     }
 }

--- a/src/cli/define/urimap-pipeline/UrimapPipeline.handler.ts
+++ b/src/cli/define/urimap-pipeline/UrimapPipeline.handler.ts
@@ -1,0 +1,51 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { AbstractSession, ICommandHandler, IHandlerParameters, IProfile, ITaskWithStatus, TaskStage } from "@zowe/imperative";
+import { defineProgram, ICMCIApiResponse, defineUrimapServer } from "../../../api";
+import { CicsBaseHandler } from "../../CicsBaseHandler";
+
+import i18nTypings from "../../-strings-/en";
+
+// Does not use the import in anticipation of some internationalization work to be done later.
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.URIMAPPIPELINE;
+
+/**
+ * Command handler for defining CICS URIMaps via CMCI
+ * @export
+ * @class ProgramHandler
+ * @implements {ICommandHandler}
+ */
+export default class UrimapPipelineHandler extends CicsBaseHandler {
+    public async processWithSession(params: IHandlerParameters, session: AbstractSession, profile: IProfile): Promise<ICMCIApiResponse> {
+
+        const status: ITaskWithStatus = {
+            statusMessage: "Defining URIMAP of type Pipeline to CICS",
+            percentComplete: 0,
+            stageName: TaskStage.IN_PROGRESS
+        };
+        params.response.progress.startBar({task: status});
+
+        const response = await defineUrimapPipeline(session, {
+            name: params.arguments.urimapName,
+            csdGroup: params.arguments.csdGroup,
+            path: params.arguments.urimapPath,
+            host: params.arguments.urimapHost,
+            pipelineName: params.arguments.pipelineName,
+            scheme: params.arguments.urimapScheme,
+            regionName: params.arguments.regionName || profile.regionName,
+            cicsPlex: params.arguments.cicsPlex || profile.cicsPlex
+        });
+
+        params.response.console.log(strings.MESSAGES.SUCCESS, params.arguments.programName);
+        return response;
+    }
+}

--- a/src/cli/define/urimap-server/UrimapServer.definition.ts
+++ b/src/cli/define/urimap-server/UrimapServer.definition.ts
@@ -1,0 +1,80 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { ICommandDefinition } from "@zowe/imperative";
+
+import i18nTypings from "../../-strings-/en";
+
+// Does not use the import in anticipation of some internationalization work to be done later.
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.URIMAPSERVER;
+
+export const UrimapServerDefinition: ICommandDefinition = {
+    name: "urimap-server", aliases: [],
+    description: strings.DESCRIPTION,
+    handler: __dirname + "/UrimapServer.handler",
+    type: "command",
+    positionals: [{
+        name: "urimapName",
+        description: strings.POSITIONALS.URIMAPNAME,
+        type: "string",
+        required: true
+    }, {
+        name: "csdGroup",
+        description: strings.POSITIONALS.CSDGROUP,
+        type: "string",
+        required: true
+    }],
+    options: [
+        {
+            name: "urimap-path",
+            aliases: ["up"],
+            description: strings.OPTIONS.URIMAPPATH,
+            type: "string",
+            required: true
+        },
+        {
+            name: "urimap-host",
+            aliases: ["uh"],
+            description: strings.OPTIONS.URIMAPHOST,
+            type: "string",
+            required: true
+        },
+        {
+            name: "urimap-scheme",
+            aliases: ["us"],
+            description: strings.OPTIONS.URIMAPSCHEME,
+            type: "string",
+            allowableValues: {values: ["http", "https"], caseSensitive: false},
+            defaultValue: "http"
+        },
+        {
+            name: "program-name",
+            aliases: ["pn"],
+            description: strings.OPTIONS.PROGRAMNAME,
+            type: "string",
+            required: true
+        },
+        {
+            name: "region-name",
+            description: strings.OPTIONS.REGIONNAME,
+            type: "string",
+        },
+        {
+            name: "cics-plex",
+            description: strings.OPTIONS.CICSPLEX,
+            type: "string"
+        }],
+    profile: {optional: ["cics"]},
+    examples: [{
+        description: strings.EXAMPLES.EX1,
+        options: "URIMAPA MYGRP --urimap-path /example/index.html --urimap-host www.example.com --program-name PGM123 --region-name MYREGION"
+    }]
+};

--- a/src/cli/define/urimap-server/UrimapServer.definition.ts
+++ b/src/cli/define/urimap-server/UrimapServer.definition.ts
@@ -17,7 +17,8 @@ import i18nTypings from "../../-strings-/en";
 const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.URIMAP;
 
 export const UrimapServerDefinition: ICommandDefinition = {
-    name: "urimap-server", aliases: [],
+    name: "urimap-server",
+    aliases: ["us"],
     description: strings.DESCRIPTION.SERVER,
     handler: __dirname + "/UrimapServer.handler",
     type: "command",
@@ -74,7 +75,7 @@ export const UrimapServerDefinition: ICommandDefinition = {
         }],
     profile: {optional: ["cics"]},
     examples: [{
-        description: strings.EXAMPLES.EX1,
+        description: strings.EXAMPLES.SERVER.EX1,
         options: "URIMAPA MYGRP --urimap-path /example/index.html --urimap-host www.example.com --program-name PGM123 --region-name MYREGION"
     }]
 };

--- a/src/cli/define/urimap-server/UrimapServer.definition.ts
+++ b/src/cli/define/urimap-server/UrimapServer.definition.ts
@@ -14,11 +14,11 @@ import { ICommandDefinition } from "@zowe/imperative";
 import i18nTypings from "../../-strings-/en";
 
 // Does not use the import in anticipation of some internationalization work to be done later.
-const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.URIMAPSERVER;
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.URIMAP;
 
 export const UrimapServerDefinition: ICommandDefinition = {
     name: "urimap-server", aliases: [],
-    description: strings.DESCRIPTION,
+    description: strings.DESCRIPTION.SERVER,
     handler: __dirname + "/UrimapServer.handler",
     type: "command",
     positionals: [{

--- a/src/cli/define/urimap-server/UrimapServer.handler.ts
+++ b/src/cli/define/urimap-server/UrimapServer.handler.ts
@@ -10,7 +10,7 @@
 */
 
 import { AbstractSession, ICommandHandler, IHandlerParameters, IProfile, ITaskWithStatus, TaskStage } from "@zowe/imperative";
-import { defineProgram, ICMCIApiResponse, defineUrimapServer } from "../../../api";
+import { ICMCIApiResponse, defineUrimapServer } from "../../../api";
 import { CicsBaseHandler } from "../../CicsBaseHandler";
 
 import i18nTypings from "../../-strings-/en";
@@ -21,7 +21,7 @@ const strings = (require("../../-strings-/en").default as typeof i18nTypings).DE
 /**
  * Command handler for defining CICS URIMaps via CMCI
  * @export
- * @class ProgramHandler
+ * @class UrimapServerHandler
  * @implements {ICommandHandler}
  */
 export default class UrimapServerHandler extends CicsBaseHandler {
@@ -45,7 +45,7 @@ export default class UrimapServerHandler extends CicsBaseHandler {
             cicsPlex: params.arguments.cicsPlex || profile.cicsPlex
         });
 
-        params.response.console.log(strings.MESSAGES.SUCCESS, params.arguments.programName);
+        params.response.console.log(strings.MESSAGES.SUCCESS, params.arguments.urimapName);
         return response;
     }
 }

--- a/src/cli/define/urimap-server/UrimapServer.handler.ts
+++ b/src/cli/define/urimap-server/UrimapServer.handler.ts
@@ -16,7 +16,7 @@ import { CicsBaseHandler } from "../../CicsBaseHandler";
 import i18nTypings from "../../-strings-/en";
 
 // Does not use the import in anticipation of some internationalization work to be done later.
-const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.URIMAPSERVER;
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.URIMAP;
 
 /**
  * Command handler for defining CICS URIMaps via CMCI

--- a/src/cli/define/urimap-server/UrimapServer.handler.ts
+++ b/src/cli/define/urimap-server/UrimapServer.handler.ts
@@ -1,0 +1,51 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { AbstractSession, ICommandHandler, IHandlerParameters, IProfile, ITaskWithStatus, TaskStage } from "@zowe/imperative";
+import { defineProgram, ICMCIApiResponse, defineUrimapServer } from "../../../api";
+import { CicsBaseHandler } from "../../CicsBaseHandler";
+
+import i18nTypings from "../../-strings-/en";
+
+// Does not use the import in anticipation of some internationalization work to be done later.
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.URIMAPSERVER;
+
+/**
+ * Command handler for defining CICS URIMaps via CMCI
+ * @export
+ * @class ProgramHandler
+ * @implements {ICommandHandler}
+ */
+export default class UrimapServerHandler extends CicsBaseHandler {
+    public async processWithSession(params: IHandlerParameters, session: AbstractSession, profile: IProfile): Promise<ICMCIApiResponse> {
+
+        const status: ITaskWithStatus = {
+            statusMessage: "Defining URIMAP of type Server to CICS",
+            percentComplete: 0,
+            stageName: TaskStage.IN_PROGRESS
+        };
+        params.response.progress.startBar({task: status});
+
+        const response = await defineUrimapServer(session, {
+            name: params.arguments.urimapName,
+            csdGroup: params.arguments.csdGroup,
+            path: params.arguments.urimapPath,
+            host: params.arguments.urimapHost,
+            programName: params.arguments.programName,
+            scheme: params.arguments.urimapScheme,
+            regionName: params.arguments.regionName || profile.regionName,
+            cicsPlex: params.arguments.cicsPlex || profile.cicsPlex
+        });
+
+        params.response.console.log(strings.MESSAGES.SUCCESS, params.arguments.programName);
+        return response;
+    }
+}

--- a/src/cli/get/resource/Resource.definition.ts
+++ b/src/cli/get/resource/Resource.definition.ts
@@ -74,14 +74,18 @@ export const ResourceDefinition: ICommandDefinition = {
         },
         {
             description: strings.EXAMPLES.EX6,
-            options: `CICSProgram --region-name MYREGION --criteria "PROGRAM=PRG*"`
+            options: `CICSDefinitionURIMap --region-name MYREGION --parameter "CSDGROUP(GRP1)"`
         },
         {
             description: strings.EXAMPLES.EX7,
-            options: `CICSLocalTransaction --region-name MYREGION --criteria "TRANID=TRAN"`
+            options: `CICSProgram --region-name MYREGION --criteria "PROGRAM=PRG*"`
         },
         {
             description: strings.EXAMPLES.EX8,
+            options: `CICSLocalTransaction --region-name MYREGION --criteria "TRANID=TRAN"`
+        },
+        {
+            description: strings.EXAMPLES.EX9,
             options: `CICSProgram --region-name MYREGION --criteria "PROGRAM=MYPRG*" --rft table --rfh --rff program length status`
         }
     ]


### PR DESCRIPTION
Adds the `cics define urimap-server`, `cics define urimap-pipeline`, and `cics define urimap-client` CLI commands, enabling functionality requested in issue #53. Also adds the API for deleting a URIMAP, simplifying future development for issue #52.