### PR TITLE
adding appscan configure file into lts-incremental branch

### DIFF
--- a/zowe-cli-cics-plugin.ppf
+++ b/zowe-cli-cics-plugin.ppf
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+  This program and the accompanying materials are made available under the terms of the
+  Eclipse Public License v2.0 which accompanies this distribution, and is available at
+  https://www.eclipse.org/legal/epl-v20.html
+  SPDX-License-Identifier: EPL-2.0
+  Copyright Contributors to the Zowe Project.
+-->
+<Project default_configuration_name="Configuration 1" fallback_default_config_name="Configuration 1" file_encoding="ISO-8859-1" ltd_name="javascript" name="zowe-cli-cics-plugin" version="9.0.3.11">
+	<Configuration name="Configuration 1"/>
+	<Source exclude="false" path="." web="false"/>
+	<ProjectScanSettings/>
+</Project>


### PR DESCRIPTION
Signed-off-by: Yan Li <raymondyanli@gmail.com>
@1000TurquoisePogs
cc @jackjia-ibm
We currently scan the source codes for branch lts-incremental in CLI group, but we don't have AppScan configure files under this branch, we have to workaround to get those configure files from other location in oder to achieve security scan. so we'd like to have those configure files in the branch its-incremental now.