### PR TITLE
Add `define webservice` command

### DIFF
--- a/__tests__/__system__/api/methods/define/Define.webservice.system.test.ts
+++ b/__tests__/__system__/api/methods/define/Define.webservice.system.test.ts
@@ -1,0 +1,139 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { Session } from "@zowe/imperative";
+import { ITestEnvironment } from "../../../../../__tests__/__src__/environment/doc/response/ITestEnvironment";
+import { TestEnvironment } from "../../../../../__tests__/__src__/environment/TestEnvironment";
+import { generateRandomAlphaNumericString } from "../../../../__src__/TestUtils";
+import { defineWebservice, deleteWebservice, IWebServiceParms } from "../../../../../src";
+
+let testEnvironment: ITestEnvironment;
+let regionName: string;
+let csdGroup: string;
+let session: Session;
+
+describe("CICS Define web service", () => {
+
+    beforeAll(async () => {
+        testEnvironment = await TestEnvironment.setUp({
+            testName: "cics_cmci_define_webservice",
+            installPlugin: true,
+            tempProfileTypes: ["cics"]
+        });
+        csdGroup = testEnvironment.systemTestProperties.cmci.csdGroup;
+        regionName = testEnvironment.systemTestProperties.cmci.regionName;
+        const cmciProperties = await testEnvironment.systemTestProperties.cmci;
+
+        session = new Session({
+            user: cmciProperties.user,
+            password: cmciProperties.password,
+            hostname: cmciProperties.host,
+            port: cmciProperties.port,
+            type: "basic",
+            strictSSL: false,
+            protocol: testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+        });
+    });
+
+    afterAll(async () => {
+        await TestEnvironment.cleanUp(testEnvironment);
+    });
+
+    const options: IWebServiceParms = {} as any;
+
+    it("should define a web service to CICS", async () => {
+        let error;
+        let response;
+
+        const websvcNameSuffixLength = 3;
+        const websvcName = "X" + generateRandomAlphaNumericString(websvcNameSuffixLength);
+
+        options.name = websvcName;
+        options.pipelineName = "AAAA1234";
+        options.wsBind = "fake";
+        options.csdGroup = csdGroup;
+        options.regionName = regionName;
+
+        try {
+            response = await defineWebservice(session, options);
+        } catch (err) {
+            error = err;
+        }
+
+        expect(error).toBeFalsy();
+        expect(response).toBeTruthy();
+        expect(response.response.resultsummary.api_response1).toBe("1024");
+        await deleteWebservice(session, options);
+    });
+
+    it("should fail to define a web service to CICS with invalid CICS region", async () => {
+        let error;
+        let response;
+
+        const websvcNameSuffixLength = 3;
+        const websvcName = "X" + generateRandomAlphaNumericString(websvcNameSuffixLength);
+
+        options.name = websvcName;
+        options.pipelineName = "AAAA1234";
+        options.wsBind = "fake";
+        options.csdGroup = csdGroup;
+        options.regionName = "FAKE";
+
+        try {
+            response = await defineWebservice(session, options);
+        } catch (err) {
+            error = err;
+        }
+
+        expect(error).toBeTruthy();
+        expect(response).toBeFalsy();
+        expect(error.message).toContain("Did not receive the expected response from CMCI REST API");
+        expect(error.message).toContain("INVALIDPARM");
+    });
+
+    it("should fail to define a web service to CICS due to duplicate name", async () => {
+        let error;
+        let response;
+
+        const websvcNameSuffixLength = 3;
+        const websvcName = "X" + generateRandomAlphaNumericString(websvcNameSuffixLength);
+
+        options.name = websvcName;
+        options.pipelineName = "AAAA1234";
+        options.wsBind = "fake";
+        options.csdGroup = csdGroup;
+        options.regionName = regionName;
+
+        // define a web service to CICS
+        try {
+            response = await defineWebservice(session, options);
+        } catch (err) {
+            error = err;
+        }
+
+        expect(error).toBeFalsy();
+        expect(response).toBeTruthy();
+        response = null; // reset
+
+        // define the same web service and validate duplicate error
+        try {
+            response = await defineWebservice(session, options);
+        } catch (err) {
+            error = err;
+        }
+
+        expect(error).toBeTruthy();
+        expect(response).toBeFalsy();
+        expect(error.message).toContain("Did not receive the expected response from CMCI REST API");
+        expect(error.message).toContain("DUPRES");
+        await deleteWebservice(session, options);
+    });
+});

--- a/__tests__/__system__/api/methods/define/Define.webservice.system.test.ts
+++ b/__tests__/__system__/api/methods/define/Define.webservice.system.test.ts
@@ -58,7 +58,8 @@ describe("CICS Define web service", () => {
 
         options.name = websvcName;
         options.pipelineName = "AAAA1234";
-        options.wsBind = "fake";
+        options.wsBind = "/u/exampleapp/wsbind/example.log";
+        options.validation = false;
         options.csdGroup = csdGroup;
         options.regionName = regionName;
 
@@ -83,7 +84,8 @@ describe("CICS Define web service", () => {
 
         options.name = websvcName;
         options.pipelineName = "AAAA1234";
-        options.wsBind = "fake";
+        options.wsBind = "/u/exampleapp/wsbind/example.log";
+        options.validation = false;
         options.csdGroup = csdGroup;
         options.regionName = "FAKE";
 
@@ -108,7 +110,8 @@ describe("CICS Define web service", () => {
 
         options.name = websvcName;
         options.pipelineName = "AAAA1234";
-        options.wsBind = "fake";
+        options.wsBind = "/u/exampleapp/wsbind/example.log";
+        options.validation = false;
         options.csdGroup = csdGroup;
         options.regionName = regionName;
 

--- a/__tests__/__system__/cli/define/webservice/__scripts__/define_webservice.sh
+++ b/__tests__/__system__/cli/define/webservice/__scripts__/define_webservice.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e # fail the script if we get a non zero exit code
+
+websvc_name=$1
+csd_group=$2
+pipeline_name=$3
+wsbind=$4
+region_name=$5
+
+zowe cics define webservice "$urimap_name" "$csd_group" --pipeline-name "$pipeline_name" --wsbind "$wsbind" --region-name "$region_name"

--- a/__tests__/__system__/cli/define/webservice/__scripts__/define_webservice.sh
+++ b/__tests__/__system__/cli/define/webservice/__scripts__/define_webservice.sh
@@ -7,4 +7,4 @@ pipeline_name=$3
 wsbind=$4
 region_name=$5
 
-zowe cics define webservice "$urimap_name" "$csd_group" --pipeline-name "$pipeline_name" --wsbind "$wsbind" --region-name "$region_name"
+zowe cics define webservice "$websvc_name" "$csd_group" --pipeline-name "$pipeline_name" --wsbind "$wsbind" --region-name "$region_name"

--- a/__tests__/__system__/cli/define/webservice/__scripts__/define_webservice_fully_qualified.sh
+++ b/__tests__/__system__/cli/define/webservice/__scripts__/define_webservice_fully_qualified.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e # fail the script if we get a non zero exit code
+
+websvc_name=$1
+csd_group=$2
+pipeline_name=$3
+wsbind=$4
+region_name=$5
+HOST=$6
+PORT=$7
+USER=$8
+PASSWORD=$9
+PROTOCOL=${10}
+REJECT=${11}
+zowe cics define webservice "$websvc_name" "$csd_group" --pipeline-name "$pipeline_name" --wsbind "$wsbind" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"

--- a/__tests__/__system__/cli/define/webservice/__scripts__/define_webservice_help.sh
+++ b/__tests__/__system__/cli/define/webservice/__scripts__/define_webservice_help.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e # fail the script if we get a non zero exit code
+
+zowe cics define webservice --help

--- a/__tests__/__system__/cli/define/webservice/__scripts__/get_resource_webservice.sh
+++ b/__tests__/__system__/cli/define/webservice/__scripts__/get_resource_webservice.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e # fail the script if we get a non zero exit code
+
+region_name=$1
+csd_group=$2
+
+zowe cics get resource CICSDefinitionWebService --region-name "$region_name" --parameter "CSDGROUP($csd_group)"

--- a/__tests__/__system__/cli/define/webservice/__scripts__/get_resource_webservice_fully_qualified.sh
+++ b/__tests__/__system__/cli/define/webservice/__scripts__/get_resource_webservice_fully_qualified.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e # fail the script if we get a non zero exit code
+
+region_name=$1
+csd_group=$2
+HOST=$3
+PORT=$4
+USER=$5
+PASSWORD=$6
+PROTOCOL=$7
+REJECT=$8
+
+zowe cics get resource CICSDefinitionWebService --region-name "$region_name" --parameter "CSDGROUP($csd_group)" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"

--- a/__tests__/__system__/cli/define/webservice/__snapshots__/cli.define.webservice.system.test.ts.snap
+++ b/__tests__/__system__/cli/define/webservice/__snapshots__/cli.define.webservice.system.test.ts.snap
@@ -1,0 +1,139 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CICS define web service command should be able to display the help 1`] = `
+"
+ COMMAND NAME
+ ------------
+
+   webservice | web
+
+ DESCRIPTION
+ -----------
+
+   Define a new web service to CICS.
+
+ USAGE
+ -----
+
+   zowe cics define webservice <webserviceName> <csdGroup> [options]
+
+ POSITIONAL ARGUMENTS
+ --------------------
+
+   webserviceName		 (string)
+
+      The name of the WEBSERVICE to create. The maximum length of the web service name
+      is eight characters.
+
+   csdGroup		 (string)
+
+      The CICS system definition (CSD) Group for the new web service that you want to
+      define. The maximum length of the group name is eight characters.
+
+ REQUIRED OPTIONS
+ ----------------
+
+   --pipeline-name  | --pn (string)
+
+      The name of the PIPELINE resource definition for the web service. The maximum
+      length of the pipeline name is eight characters
+
+   --wsbind  (string)
+
+      The file name of the web service binding file on HFS.
+
+ OPTIONS
+ -------
+
+   --description  | --desc (string)
+
+      Description of the web service resource being defined.
+
+   --validation  (boolean)
+
+      Specifies whether full validation of SOAP messages against the corresponding
+      schema in the web service description should be performed at run time.
+
+   --wsdlfile  | --wsdl (string)
+
+      The file name of the web service description (WSDL) file on HFS.
+
+   --region-name  (string)
+
+      The CICS region name to which to define the new web service.
+
+   --cics-plex  (string)
+
+      The name of the CICSPlex to which to define the new web service.
+
+ CICS CONNECTION OPTIONS
+ -----------------------
+
+   --host  | -H (string)
+
+      The CICS server host name.
+
+   --port  | -P (number)
+
+      The CICS server port.
+
+      Default value: 443
+
+   --user  | -u (string)
+
+      Mainframe (CICS) user name, which can be the same as your TSO login.
+
+   --password  | --pw (string)
+
+      Mainframe (CICS) password, which can be the same as your TSO password.
+
+   --reject-unauthorized  | --ru (boolean)
+
+      Reject self-signed certificates.
+
+      Default value: true
+
+   --protocol  | -o (string)
+
+      Specifies CMCI protocol (http or https).
+
+      Default value: http
+      Allowed values: http, https
+
+ PROFILE OPTIONS
+ ---------------
+
+   --cics-profile  | --cics-p (string)
+
+      The name of a (cics) profile to load for this command execution.
+
+ GLOBAL OPTIONS
+ --------------
+
+   --response-format-json  | --rfj (boolean)
+
+      Produce JSON formatted data from a command
+
+   --help  | -h (boolean)
+
+      Display help text
+
+   --help-examples  (boolean)
+
+      Display examples for all the commands in a the group
+
+   --help-web  | --hw (boolean)
+
+      Display HTML help in browser
+
+ EXAMPLES
+ --------
+
+   - Define a webservice named WEBSVCA for the pipeline named
+   PIPE123 to the region named MYREGION in the CSD group MYGRP where the binding
+   file is /u/exampleapp/wsbind/example.log:
+
+      $ zowe cics define webservice WEBSVCA MYGRP --pipeline-name PIPELINE --wsbind /u/exampleapp/wsbind/example.log --region-name MYREGION
+
+"
+`;

--- a/__tests__/__system__/cli/define/webservice/cli.define.webservice.system.test.ts
+++ b/__tests__/__system__/cli/define/webservice/cli.define.webservice.system.test.ts
@@ -1,0 +1,177 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { TestEnvironment } from "../../../../__src__/environment/TestEnvironment";
+import { ITestEnvironment } from "../../../../__src__/environment/doc/response/ITestEnvironment";
+import { generateRandomAlphaNumericString, runCliScript } from "../../../../__src__/TestUtils";
+import { Session } from "@zowe/imperative";
+import { IWebServiceParms } from "../../../../../src";
+import { deleteWebservice } from "../../../../../src/api/methods/delete/Delete";
+
+let TEST_ENVIRONMENT: ITestEnvironment;
+let regionName: string;
+let csdGroup: string;
+let host: string;
+let port: number;
+let user: string;
+let password: string;
+let protocol: string;
+let rejectUnauthorized: boolean;
+let session: Session;
+
+describe("CICS define web service command", () => {
+
+    beforeAll(async () => {
+        TEST_ENVIRONMENT = await TestEnvironment.setUp({
+            testName: "define_webservice",
+            installPlugin: true,
+            tempProfileTypes: ["cics"]
+        });
+        const cmciProperties = TEST_ENVIRONMENT.systemTestProperties.cmci;
+        csdGroup = TEST_ENVIRONMENT.systemTestProperties.cmci.csdGroup;
+        regionName = TEST_ENVIRONMENT.systemTestProperties.cmci.regionName;
+        host = TEST_ENVIRONMENT.systemTestProperties.cmci.host;
+        port = TEST_ENVIRONMENT.systemTestProperties.cmci.port;
+        user = TEST_ENVIRONMENT.systemTestProperties.cmci.user;
+        password = TEST_ENVIRONMENT.systemTestProperties.cmci.password;
+        protocol = TEST_ENVIRONMENT.systemTestProperties.cmci.protocol;
+        rejectUnauthorized = TEST_ENVIRONMENT.systemTestProperties.cmci.rejectUnauthorized;
+        session = new Session({
+            type: "basic",
+            hostname: cmciProperties.host,
+            port: cmciProperties.port,
+            user: cmciProperties.user,
+            password: cmciProperties.password,
+            strictSSL: false,
+            protocol: "http",
+        });
+    });
+
+    afterAll(async () => {
+        await TestEnvironment.cleanUp(TEST_ENVIRONMENT);
+    });
+
+    it("should be able to display the help", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_webservice_help.sh", TEST_ENVIRONMENT, []);
+        expect(output.stderr.toString()).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toMatchSnapshot();
+    });
+
+    it("should be able to successfully define a web service with basic options", async () => {
+        const websvcNameSuffixLength = 4;
+        const websvcName = "DFN" + generateRandomAlphaNumericString(websvcNameSuffixLength);
+        const options: IWebServiceParms = { name: websvcName, csdGroup, regionName };
+        let output = runCliScript(__dirname + "/__scripts__/define_webservice.sh", TEST_ENVIRONMENT,
+            [websvcName, csdGroup, "FAKEPIPE", "//u/exampleapp/wsbind/example.log", regionName]);
+        let stderr = output.stderr.toString();
+        expect(stderr).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toContain("success");
+
+        output = runCliScript(__dirname + "/__scripts__/get_resource_webservice.sh", TEST_ENVIRONMENT,
+            [regionName, csdGroup]);
+        stderr = output.stderr.toString();
+        expect(stderr).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toContain(websvcName);
+        expect(output.stdout.toString()).toContain("ENABLED");
+
+        await deleteWebservice(session, options);
+    });
+
+    it("should get a syntax error if web service name is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_webservice.sh", TEST_ENVIRONMENT,
+            ["", "FAKEGRP", "FAKEPIPE", "FAKEWSB", "FAKERGN"]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("webserviceName");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should get a syntax error if CSD group is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_webservice.sh", TEST_ENVIRONMENT,
+            ["FAKEWSVC", "", "FAKEPIPE", "FAKEWSB", "FAKERGN"]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("csdGroup");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should get a syntax error if web service pipeline name is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_webservice.sh", TEST_ENVIRONMENT,
+            ["FAKEWSVC", "FAKEGRP", "", "FAKEWSB", "FAKERGN"]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("pipeline-name");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should get a syntax error if web service binding file is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_webservice.sh", TEST_ENVIRONMENT,
+            ["FAKEWSVC", "FAKEGRP", "FAKEPIPE", "", "FAKERGN"]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("wsbind");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should get a syntax error if region name is omitted", () => {
+        const output = runCliScript(__dirname + "/__scripts__/define_webservice.sh", TEST_ENVIRONMENT,
+            ["FAKEWSVC", "FAKEGRP", "FAKEPIPE", "FAKEWSB", ""]);
+        const stderr = output.stderr.toString();
+        expect(stderr).toContain("Syntax");
+        expect(stderr).toContain("region-name");
+        expect(output.status).toEqual(1);
+    });
+
+    it("should be able to successfully define a web service using profile options", async () => {
+        const websvcNameSuffixLength = 4;
+        const websvcName = "DFN" + generateRandomAlphaNumericString(websvcNameSuffixLength);
+        const pipelineName = "FAKEPIPE";
+        const wsBind = "//u/exampleapp/wsbind/example.log";
+        const options: IWebServiceParms = { name: websvcName, csdGroup, regionName };
+        let output = runCliScript(__dirname + "/__scripts__/define_webservice_fully_qualified.sh", TEST_ENVIRONMENT,
+            [websvcName,
+                csdGroup,
+                pipelineName,
+                wsBind,
+                regionName,
+                host,
+                port,
+                user,
+                password,
+                protocol,
+                rejectUnauthorized]);
+        let stderr = output.stderr.toString();
+        expect(stderr).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toContain("success");
+
+        output = runCliScript(__dirname + "/__scripts__/get_resource_webservice_fully_qualified.sh", TEST_ENVIRONMENT,
+            [regionName,
+                csdGroup,
+                host,
+                port,
+                user,
+                password,
+                protocol,
+                rejectUnauthorized]);
+        stderr = output.stderr.toString();
+        expect(stderr).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toContain(websvcName);
+        expect(output.stdout.toString()).toContain("ENABLED");
+
+        await deleteWebservice(session, options);
+    });
+
+});

--- a/__tests__/__system__/cli/define/webservice/cli.define.webservice.system.test.ts
+++ b/__tests__/__system__/cli/define/webservice/cli.define.webservice.system.test.ts
@@ -83,7 +83,6 @@ describe("CICS define web service command", () => {
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
         expect(output.stdout.toString()).toContain(websvcName);
-        expect(output.stdout.toString()).toContain("ENABLED");
 
         await deleteWebservice(session, options);
     });
@@ -169,7 +168,6 @@ describe("CICS define web service command", () => {
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
         expect(output.stdout.toString()).toContain(websvcName);
-        expect(output.stdout.toString()).toContain("ENABLED");
 
         await deleteWebservice(session, options);
     });

--- a/__tests__/api/methods/define/Define.webservice.unit.test.ts
+++ b/__tests__/api/methods/define/Define.webservice.unit.test.ts
@@ -1,0 +1,341 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { Session } from "@zowe/imperative";
+import { CicsCmciRestClient, CicsCmciConstants, IWebServiceParms, defineWebservice } from "../../../../src";
+
+describe("CMCI - Define web service", () => {
+
+    const websvc = "websvc";
+    const group = "group";
+    const pipeline = "pipeline";
+    const wsBind = "wsbind";
+    const region = "region";
+    const cicsPlex = "plex";
+    const content = "This\nis\r\na\ntest";
+
+    const defineParms: IWebServiceParms  = {
+        name: websvc,
+        pipelineName: pipeline,
+        wsBind,
+        validation: false,
+        regionName: region,
+        csdGroup: group,
+        cicsPlex: undefined
+    };
+
+    const dummySession = new Session({
+        user: "fake",
+        password: "fake",
+        hostname: "fake",
+        port: 1490
+    });
+
+    let error: any;
+    let response: any;
+    let endPoint: string;
+
+    describe("validation", () => {
+        beforeEach(() => {
+            response = undefined;
+            error = undefined;
+        });
+
+        it("should throw error if no parms are defined", async () => {
+            try {
+                response = await defineWebservice(dummySession, undefined);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Cannot read property 'name' of undefined");
+        });
+
+        it("should throw error if web service name is not defined", async () => {
+            try {
+                response = await defineWebservice(dummySession, {
+                    name: undefined,
+                    csdGroup: "fake",
+                    pipelineName: "fake",
+                    wsBind: "fake",
+                    validation: false,
+                    regionName: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS web service name is required");
+        });
+
+        it("should throw error if CSD group is not defined", async () => {
+            try {
+                response = await defineWebservice(dummySession, {
+                    name: "fake",
+                    csdGroup: undefined,
+                    pipelineName: "fake",
+                    wsBind: "fake",
+                    validation: false,
+                    regionName: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS CSD group is required");
+        });
+
+        it("should throw error if web service pipeline name is not defined", async () => {
+            try {
+                response = await defineWebservice(dummySession, {
+                    name: "fake",
+                    csdGroup: "fake",
+                    pipelineName: undefined,
+                    wsBind: "fake",
+                    validation: false,
+                    regionName: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS pipeline name is required");
+        });
+
+        it("should throw error if web service binding file is not defined", async () => {
+            try {
+                response = await defineWebservice(dummySession, {
+                    name: "fake",
+                    csdGroup: "fake",
+                    pipelineName: "fake",
+                    wsBind: undefined,
+                    validation: false,
+                    regionName: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS web service binding file is required");
+        });
+
+        it("should throw error if web service validation is not defined", async () => {
+            try {
+                response = await defineWebservice(dummySession, {
+                    name: "fake",
+                    csdGroup: "fake",
+                    pipelineName: "fake",
+                    wsBind: "fake",
+                    validation: undefined,
+                    regionName: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS web service validation is required");
+        });
+
+        it("should throw error if CICS Region name is not defined", async () => {
+            try {
+                response = await defineWebservice(dummySession, {
+                    name: "fake",
+                    csdGroup: "fake",
+                    pipelineName: "fake",
+                    wsBind: "fake",
+                    validation: false,
+                    regionName: undefined
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS region name is required");
+        });
+
+        it("should throw error if web service name is missing", async () => {
+            try {
+                response = await defineWebservice(dummySession, {
+                    name: "",
+                    csdGroup: "fake",
+                    pipelineName: "fake",
+                    wsBind: "fake",
+                    validation: false,
+                    regionName: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS Web service name' must not be blank");
+        });
+
+        it("should throw error if CSD group is missing", async () => {
+            try {
+                response = await defineWebservice(dummySession, {
+                    name: "fake",
+                    csdGroup: "",
+                    pipelineName: "fake",
+                    wsBind: "fake",
+                    validation: false,
+                    regionName: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS CSD Group' must not be blank");
+        });
+
+        it("should throw error if web service pipeline name is missing", async () => {
+            try {
+                response = await defineWebservice(dummySession, {
+                    name: "fake",
+                    csdGroup: "fake",
+                    pipelineName: "",
+                    wsBind: "fake",
+                    validation: false,
+                    regionName: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS Pipeline name' must not be blank");
+        });
+
+        it("should throw error if web service binding file is missing", async () => {
+            try {
+                response = await defineWebservice(dummySession, {
+                    name: "fake",
+                    csdGroup: "fake",
+                    pipelineName: "fake",
+                    wsBind: "",
+                    validation: false,
+                    regionName: "fake"
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS Web service binding file' must not be blank");
+        });
+
+        it("should throw error if CICS Region name is missing", async () => {
+            try {
+                response = await defineWebservice(dummySession, {
+                    name: "fake",
+                    csdGroup: "fake",
+                    pipelineName: "fake",
+                    wsBind: "fake",
+                    validation: false,
+                    regionName: ""
+                });
+            } catch (err) {
+                error = err;
+            }
+
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("Required parameter 'CICS Region name' must not be blank");
+        });
+    });
+
+    describe("success scenarios", () => {
+
+        const requestBody: any = {
+            request: {
+                create: {
+                    parameter: {
+                        $: {
+                            name: "CSD",
+                        }
+                    },
+                    attributes: {
+                        $: {
+                            name: websvc,
+                            csdgroup: group,
+                            pipeline,
+                            wsbind: wsBind,
+                            validation: "no"
+                        }
+                    }
+                }
+            }
+        };
+
+        const defineSpy = jest.spyOn(CicsCmciRestClient, "postExpectParsedXml").mockReturnValue(content);
+
+        beforeEach(() => {
+            response = undefined;
+            error = undefined;
+            defineSpy.mockClear();
+            defineSpy.mockImplementation(() => content);
+        });
+
+        it("should be able to define a web service without cicsPlex specified", async () => {
+            endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+                CicsCmciConstants.CICS_DEFINITION_WEBSERVICE + "/" + region;
+
+            response = await defineWebservice(dummySession, defineParms);
+
+            // expect(response.success).toBe(true);
+            expect(response).toContain(content);
+            expect(defineSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+        });
+
+        it("should be able to define a web service with cicsPlex specified but empty string", async () => {
+            defineParms.cicsPlex = "";
+            endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+                CicsCmciConstants.CICS_DEFINITION_WEBSERVICE + "//" + region;
+
+            response = await defineWebservice(dummySession, defineParms);
+
+            // expect(response.success).toBe(true);
+            expect(response).toContain(content);
+            expect(defineSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+        });
+
+        it("should be able to define a web service with cicsPlex specified", async () => {
+            defineParms.cicsPlex = cicsPlex;
+            endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+                CicsCmciConstants.CICS_DEFINITION_WEBSERVICE + "/" + cicsPlex +"/" + region;
+
+            response = await defineWebservice(dummySession, defineParms);
+
+            // expect(response.success).toBe(true);
+            expect(response).toContain(content);
+            expect(defineSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+        });
+    });
+});

--- a/__tests__/cli/define/Define.definition.unit.test.ts
+++ b/__tests__/cli/define/Define.definition.unit.test.ts
@@ -12,7 +12,7 @@
 import { ICommandDefinition } from "@zowe/imperative";
 
 describe("cics define program", () => {
-    const DEFINE_RESOURCES = 5;
+    const DEFINE_RESOURCES = 6;
 
     it ("should not have changed", () => {
         const definition: ICommandDefinition = require("../../../src/cli/define/Define.definition");

--- a/__tests__/cli/define/webservice/Webservice.definition.unit.test.ts
+++ b/__tests__/cli/define/webservice/Webservice.definition.unit.test.ts
@@ -9,51 +9,14 @@
 *                                                                                 *
 */
 
-export interface IWebServiceParms {
-    /**
-     * The name of the webservice
-     * Up to eight characters long
-     */
-    name: string;
+import { ICommandDefinition } from "@zowe/imperative";
 
-    /**
-     * CSD group for the webservice
-     * Up to eight characters long
-     */
-    csdGroup: string;
-
-    /**
-     *
-     */
-    pipelineName: string;
-
-    /**
-     *
-     */
-    wsBind: string;
-
-    /**
-     *
-     */
-    description?: string;
-
-    /**
-     *
-     */
-    validation: boolean;
-
-    /**
-     *
-     */
-    wsdlFile?: string;
-
-    /**
-     * The name of the CICS region of the webservice
-     */
-    regionName: string;
-
-    /**
-     * CICS Plex of the webservice
-     */
-    cicsPlex?: string;
-}
+describe("cics define webservice", () => {
+    it ("should not have changed", () => {
+        const path = "../../../../src/cli/define/webservice/WebService.definition";
+        const definition: ICommandDefinition = require(path).WebServiceDefinition;
+        expect(definition).toBeDefined();
+        delete definition.handler;
+        expect(definition).toMatchSnapshot();
+    });
+});

--- a/__tests__/cli/define/webservice/Webservice.definition.unit.test.ts
+++ b/__tests__/cli/define/webservice/Webservice.definition.unit.test.ts
@@ -13,7 +13,7 @@ import { ICommandDefinition } from "@zowe/imperative";
 
 describe("cics define webservice", () => {
     it ("should not have changed", () => {
-        const path = "../../../../src/cli/define/webservice/WebService.definition";
+        const path = "../../../../src/cli/define/webservice/Webservice.definition";
         const definition: ICommandDefinition = require(path).WebServiceDefinition;
         expect(definition).toBeDefined();
         delete definition.handler;

--- a/__tests__/cli/define/webservice/Webservice.handler.unit.test.ts
+++ b/__tests__/cli/define/webservice/Webservice.handler.unit.test.ts
@@ -1,0 +1,141 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { CommandProfiles, IHandlerParameters, IProfile, Session } from "@zowe/imperative";
+import { ICMCIApiResponse } from "../../../../src";
+import { WebServiceDefinition } from "../../../../src/cli/define/webservice/WebService.definition";
+import WebServiceHandler from "../../../../src/cli/define/webservice/WebService.handler";
+
+jest.mock("../../../../src/api/methods/define");
+const Define = require("../../../../src/api/methods/define");
+
+const host = "somewhere.com";
+const port = "43443";
+const user = "someone";
+const password = "somesecret";
+const protocol = "http";
+const rejectUnauthorized = false;
+
+const PROFILE_MAP = new Map<string, IProfile[]>();
+PROFILE_MAP.set(
+    "cics", [{
+        name: "cics",
+        type: "cics",
+        host,
+        port,
+        user,
+        password
+    }]
+);
+const PROFILES: CommandProfiles = new CommandProfiles(PROFILE_MAP);
+const DEFAULT_PARAMETERS: IHandlerParameters = {
+    arguments: {$0: "", _: []}, // Please provide arguments later on
+    response: {
+        data: {
+            setMessage: jest.fn((setMsgArgs) => {
+                expect(setMsgArgs).toMatchSnapshot();
+            }),
+            setObj: jest.fn((setObjArgs) => {
+                expect(setObjArgs).toMatchSnapshot();
+            }),
+            setExitCode: jest.fn()
+        },
+        console: {
+            log: jest.fn((logs) => {
+                expect(logs.toString()).toMatchSnapshot();
+            }),
+            error: jest.fn((errors) => {
+                expect(errors.toString()).toMatchSnapshot();
+            }),
+            errorHeader: jest.fn(() => undefined)
+        },
+        progress: {
+            startBar: jest.fn((parms) => undefined),
+            endBar: jest.fn(() => undefined)
+        },
+        format: {
+            output: jest.fn((parms) => {
+                expect(parms).toMatchSnapshot();
+            })
+        }
+    },
+    definition: WebServiceDefinition,
+    fullDefinition: WebServiceDefinition,
+    profiles: PROFILES
+};
+
+describe("DefineWebserviceHandler", () => {
+    const websvcName = "testWebsvc";
+    const csdGroup = "testGroup";
+    const pipelineName = "testPipeline";
+    const wsBind = "testWsbind";
+    const regionName = "testRegion";
+    const cicsPlex = "testPlex";
+
+    const defaultReturn: ICMCIApiResponse = {
+        response: {
+            resultsummary: {api_response1: "1024", api_response2: "0", recordcount: "0", displayed_recordcount: "0"},
+            records: "testing"
+        }
+    };
+
+    const functionSpy = jest.spyOn(Define, "defineWebservice");
+
+    beforeEach(() => {
+        functionSpy.mockClear();
+        functionSpy.mockImplementation(async () => defaultReturn);
+    });
+
+    it("should call the defineWebservice api", async () => {
+        const handler = new WebServiceHandler();
+
+        const commandParameters = {...DEFAULT_PARAMETERS};
+        commandParameters.arguments = {
+            ...commandParameters.arguments,
+            webserviceName: websvcName,
+            csdGroup,
+            pipelineName,
+            wsbind: wsBind,
+            regionName,
+            cicsPlex,
+            host,
+            port,
+            user,
+            password,
+            rejectUnauthorized,
+            protocol
+        };
+
+        await handler.process(commandParameters);
+
+        expect(functionSpy).toHaveBeenCalledTimes(1);
+        const testProfile = PROFILE_MAP.get("cics")[0];
+        expect(functionSpy).toHaveBeenCalledWith(
+            new Session({
+                type: "basic",
+                hostname: testProfile.host,
+                port: testProfile.port,
+                user: testProfile.user,
+                password: testProfile.password,
+                rejectUnauthorized,
+                protocol
+            }),
+            {
+                name: websvcName,
+                csdGroup,
+                pipelineName,
+                wsBind,
+                regionName,
+                cicsPlex
+            }
+        );
+    });
+});

--- a/__tests__/cli/define/webservice/Webservice.handler.unit.test.ts
+++ b/__tests__/cli/define/webservice/Webservice.handler.unit.test.ts
@@ -11,8 +11,8 @@
 
 import { CommandProfiles, IHandlerParameters, IProfile, Session } from "@zowe/imperative";
 import { ICMCIApiResponse } from "../../../../src";
-import { WebServiceDefinition } from "../../../../src/cli/define/webservice/WebService.definition";
-import WebServiceHandler from "../../../../src/cli/define/webservice/WebService.handler";
+import { WebServiceDefinition } from "../../../../src/cli/define/webservice/Webservice.definition";
+import WebServiceHandler from "../../../../src/cli/define/webservice/Webservice.handler";
 
 jest.mock("../../../../src/api/methods/define");
 const Define = require("../../../../src/api/methods/define");

--- a/__tests__/cli/define/webservice/__snapshots__/Webservice.definition.unit.test.ts.snap
+++ b/__tests__/cli/define/webservice/__snapshots__/Webservice.definition.unit.test.ts.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cics define webservice should not have changed 1`] = `
+Object {
+  "aliases": Array [
+    "web",
+  ],
+  "description": "Define a new web service to CICS.",
+  "examples": Array [
+    Object {
+      "description": "Define a webservice named WEBSVCA for the pipeline named PIPE123 to the region named MYREGION in the CSD group MYGRP where the binding file is /u/exampleapp/wsbind/example.log",
+      "options": "WEBSVCA MYGRP --pipeline-name PIPELINE --wsbind /u/exampleapp/wsbind/example.log --region-name MYREGION",
+    },
+  ],
+  "name": "webservice",
+  "options": Array [
+    Object {
+      "aliases": Array [
+        "pn",
+      ],
+      "description": "The name of the PIPELINE resource definition for the web service. The maximum length of the pipeline name is eight characters",
+      "name": "pipeline-name",
+      "required": true,
+      "type": "string",
+    },
+    Object {
+      "description": "The file name of the web service binding file on HFS.",
+      "name": "wsbind",
+      "required": true,
+      "type": "string",
+    },
+    Object {
+      "aliases": Array [
+        "desc",
+      ],
+      "description": "Description of the web service resource being defined.",
+      "name": "description",
+      "type": "string",
+    },
+    Object {
+      "defaultValue": false,
+      "description": "Specifies whether full validation of SOAP messages against the corresponding schema in the web service description should be performed at run time.",
+      "name": "validation",
+      "type": "boolean",
+    },
+    Object {
+      "aliases": Array [
+        "wsdl",
+      ],
+      "description": "The file name of the web service description (WSDL) file on HFS.",
+      "name": "wsdlfile",
+      "type": "string",
+    },
+    Object {
+      "description": "The CICS region name to which to define the new web service.",
+      "name": "region-name",
+      "type": "string",
+    },
+    Object {
+      "description": "The name of the CICSPlex to which to define the new web service.",
+      "name": "cics-plex",
+      "type": "string",
+    },
+  ],
+  "positionals": Array [
+    Object {
+      "description": "The name of the WEBSERVICE to create. The maximum length of the web service name is eight characters.",
+      "name": "webserviceName",
+      "required": true,
+      "type": "string",
+    },
+    Object {
+      "description": "The CICS system definition (CSD) Group for the new web service that you want to define. The maximum length of the group name is eight characters.",
+      "name": "csdGroup",
+      "required": true,
+      "type": "string",
+    },
+  ],
+  "profile": Object {
+    "optional": Array [
+      "cics",
+    ],
+  },
+  "type": "command",
+}
+`;

--- a/__tests__/cli/define/webservice/__snapshots__/Webservice.handler.unit.test.ts.snap
+++ b/__tests__/cli/define/webservice/__snapshots__/Webservice.handler.unit.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DefineWebserviceHandler should call the defineWebservice api 1`] = `"The WEBSERVICE '%s' was defined successfully."`;
+
+exports[`DefineWebserviceHandler should call the defineWebservice api 2`] = `
+Object {
+  "response": Object {
+    "records": "testing",
+    "resultsummary": Object {
+      "api_response1": "1024",
+      "api_response2": "0",
+      "displayed_recordcount": "0",
+      "recordcount": "0",
+    },
+  },
+}
+`;

--- a/src/api/constants/CicsCmci.constants.ts
+++ b/src/api/constants/CicsCmci.constants.ts
@@ -44,6 +44,11 @@ export const CicsCmciConstants: { [key: string]: any } = {
     CICS_DEFINITION_URIMAP: "CICSDefinitionURIMap",
 
     /**
+     * Specifies the required part of the REST interface URI to access webservice definitions
+     */
+    CICS_DEFINITION_WEBSERVICE: "CICSDefinitionWebService",
+
+    /**
      * ORDERBY parameter
      */
     ORDER_BY: "ORDERBY",

--- a/src/api/doc/IWebServiceParms.ts
+++ b/src/api/doc/IWebServiceParms.ts
@@ -9,10 +9,51 @@
 *                                                                                 *
 */
 
-export * from "./ICMCIApiResponse";
-export * from "./ICMCIResponseResultSummary";
-export * from "./IProgramParms";
-export * from "./IResourceParms";
-export * from "./ITransactionParms";
-export * from "./IURIMapParms";
-export * from "./IWebServiceParms";
+export interface IWebServiceParms {
+    /**
+     * The name of the webservice
+     * Up to eight characters long
+     */
+    name: string;
+
+    /**
+     * CSD group for the webservice
+     * Up to eight characters long
+     */
+    csdGroup: string;
+
+    /**
+     *
+     */
+    pipeline: string;
+
+    /**
+     *
+     */
+    wsBind: string;
+
+    /**
+     *
+     */
+    description?: string;
+
+    /**
+     *
+     */
+    validation: boolean;
+
+    /**
+     *
+     */
+    wsdlFile: string;
+
+    /**
+     * The name of the CICS region of the webservice
+     */
+    regionName: string;
+
+    /**
+     * CICS Plex of the webservice
+     */
+    cicsPlex?: string;
+}

--- a/src/api/doc/IWebServiceParms.ts
+++ b/src/api/doc/IWebServiceParms.ts
@@ -25,12 +25,12 @@ export interface IWebServiceParms {
     /**
      *
      */
-    pipelineName: string;
+    pipelineName?: string;
 
     /**
      *
      */
-    wsBind: string;
+    wsBind?: string;
 
     /**
      *
@@ -40,7 +40,7 @@ export interface IWebServiceParms {
     /**
      *
      */
-    validation: boolean;
+    validation?: boolean;
 
     /**
      *

--- a/src/api/doc/IWebServiceParms.ts
+++ b/src/api/doc/IWebServiceParms.ts
@@ -11,49 +11,54 @@
 
 export interface IWebServiceParms {
     /**
-     * The name of the webservice
+     * The name of the web service
      * Up to eight characters long
      */
     name: string;
 
     /**
-     * CSD group for the webservice
+     * CSD group for the web service
      * Up to eight characters long
      */
     csdGroup: string;
 
     /**
-     *
+     * Pipeline name for the web service
+     * Up to eight characters long
      */
     pipelineName?: string;
 
     /**
-     *
+     * Web service binding file on HFS
+     * Should be a fully qualified file name
      */
     wsBind?: string;
 
     /**
-     *
+     * Description text for the web service
      */
     description?: string;
 
     /**
-     *
+     * Specifies whether full validation of SOAP messages against the
+     * corresponding schema in the web service description should be performed
+     * at run time
      */
     validation?: boolean;
 
     /**
-     *
+     * Web service description file on HFS
+     * Should be a fully qualified file name
      */
     wsdlFile?: string;
 
     /**
-     * The name of the CICS region of the webservice
+     * The name of the CICS region of the web service
      */
     regionName: string;
 
     /**
-     * CICS Plex of the webservice
+     * CICS Plex of the web service
      */
     cicsPlex?: string;
 }

--- a/src/api/methods/define/Define.ts
+++ b/src/api/methods/define/Define.ts
@@ -12,7 +12,7 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
-import { ICMCIApiResponse, IProgramParms, ITransactionParms, IURIMapParms } from "../../doc";
+import { ICMCIApiResponse, IProgramParms, ITransactionParms, IURIMapParms, IWebServiceParms } from "../../doc";
 
 /**
  * Define a new program resource to CICS through CMCI REST API
@@ -231,4 +231,52 @@ function buildUrimapRequestBody(parms: IURIMapParms, usage: "server" | "client" 
             }
         }
     };
+}
+
+export async function defineWebservice(session: AbstractSession, parms: IWebServiceParms): Promise<ICMCIApiResponse> {
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.name, "CICS Web service name", "CICS web service name is required");
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.pipeline, "CICS Pipeline name", "CICS pipeline name is required");
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.wsBind, "CICS Web service binding file", "CICS web service binding file is required");
+    ImperativeExpect.toNotBeNullOrUndefined(parms.validation, "CICS web service validation is required");
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.csdGroup, "CICS CSD Group", "CICS CSD group is required");
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.regionName, "CICS Region name", "CICS region name is required");
+
+    Logger.getAppLogger().debug("Attempting to define a web service with the following parameters:\n%s", JSON.stringify(parms));
+    const requestAttrs: any = {
+        name: parms.name,
+        csdgroup: parms.csdGroup,
+        pipeline: parms.pipeline,
+        wsbind: parms.wsBind,
+        validation: parms.validation ? "yes" : "no"
+    };
+
+    if (parms.description != null) {
+        requestAttrs.description = parms.description;
+    }
+
+    if (parms.wsdlFile != null) {
+        requestAttrs.wsdlFile = parms.wsdlFile;
+    }
+
+    const requestBody: any = {
+        request: {
+            create: {
+                parameter: {
+                    $: {
+                        name: "CSD",
+                    }
+                },
+                attributes: {
+                    $: requestAttrs
+                }
+            }
+        }
+    };
+
+    const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
+    const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+        CicsCmciConstants.CICS_DEFINITION_WEBSERVICE + "/" + cicsPlex +
+        parms.regionName;
+    return CicsCmciRestClient.postExpectParsedXml(session, cmciResource,
+        [], requestBody) as any;
 }

--- a/src/api/methods/define/Define.ts
+++ b/src/api/methods/define/Define.ts
@@ -235,7 +235,7 @@ function buildUrimapRequestBody(parms: IURIMapParms, usage: "server" | "client" 
 
 export async function defineWebservice(session: AbstractSession, parms: IWebServiceParms): Promise<ICMCIApiResponse> {
     ImperativeExpect.toBeDefinedAndNonBlank(parms.name, "CICS Web service name", "CICS web service name is required");
-    ImperativeExpect.toBeDefinedAndNonBlank(parms.pipeline, "CICS Pipeline name", "CICS pipeline name is required");
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.pipelineName, "CICS Pipeline name", "CICS pipeline name is required");
     ImperativeExpect.toBeDefinedAndNonBlank(parms.wsBind, "CICS Web service binding file", "CICS web service binding file is required");
     ImperativeExpect.toNotBeNullOrUndefined(parms.validation, "CICS web service validation is required");
     ImperativeExpect.toBeDefinedAndNonBlank(parms.csdGroup, "CICS CSD Group", "CICS CSD group is required");
@@ -245,7 +245,7 @@ export async function defineWebservice(session: AbstractSession, parms: IWebServ
     const requestAttrs: any = {
         name: parms.name,
         csdgroup: parms.csdGroup,
-        pipeline: parms.pipeline,
+        pipeline: parms.pipelineName,
         wsbind: parms.wsBind,
         validation: parms.validation ? "yes" : "no"
     };

--- a/src/api/methods/delete/Delete.ts
+++ b/src/api/methods/delete/Delete.ts
@@ -12,7 +12,7 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
-import { ICMCIApiResponse, IProgramParms, ITransactionParms, IURIMapParms } from "../../doc";
+import { ICMCIApiResponse, IProgramParms, ITransactionParms, IURIMapParms, IWebServiceParms } from "../../doc";
 
 /**
  * Delete a program installed in CICS through CMCI REST API
@@ -83,6 +83,31 @@ export async function deleteUrimap(session: AbstractSession, parms: IURIMapParms
     const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
     const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
         CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex +
+        `${parms.regionName}?CRITERIA=(NAME=${parms.name})&PARAMETER=CSDGROUP(${parms.csdGroup})`;
+    return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []);
+}
+
+/**
+ * Delete a web service installed in CICS through CMCI REST API
+ * @param {AbstractSession} session - the session to connect to CMCI with
+ * @param {IWebServiceParms} parms - parameters for deleting your web service
+ * @returns {Promise<ICMCIApiResponse>} promise that resolves to the response (XML parsed into a javascript object)
+ *                          when the request is complete
+ * @throws {ImperativeError} CICS Web service name not defined or blank
+ * @throws {ImperativeError} CICS CSD group not defined or blank
+ * @throws {ImperativeError} CICS region name not defined or blank
+ * @throws {ImperativeError} CicsCmciRestClient request fails
+ */
+export async function deleteWebservice(session: AbstractSession, parms: IWebServiceParms): Promise<ICMCIApiResponse> {
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.name, "CICS Web service name", "CICS Web service name is required");
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.csdGroup, "CICS CSD Group", "CICS CSD group is required");
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.regionName, "CICS Region name", "CICS region name is required");
+
+    Logger.getAppLogger().debug("Attempting to delete a web service with the following parameters:\n%s", JSON.stringify(parms));
+
+    const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
+    const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+        CicsCmciConstants.CICS_DEFINITION_WEBSERVICE + "/" + cicsPlex +
         `${parms.regionName}?CRITERIA=(NAME=${parms.name})&PARAMETER=CSDGROUP(${parms.csdGroup})`;
     return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []);
 }

--- a/src/cli/-strings-/en.ts
+++ b/src/cli/-strings-/en.ts
@@ -93,6 +93,32 @@ export default {
                             "in the CSD group MYGRP where the host is www.example.com and the path is /example/index.html"
                     }
                 }
+            },
+            WEBSERVICE: {
+                DESCRIPTION: "Define a new web service to CICS.",
+                POSITIONALS: {
+                    WEBSERVICENAME: "The name of the WEBSERVICE to create. The maximum length of the web service name is eight characters.",
+                    CSDGROUP: "The CICS system definition (CSD) Group for the new web service that you want to define." +
+                        " The maximum length of the group name is eight characters."
+                },
+                OPTIONS: {
+                    PIPELINENAME: "The name of the PIPELINE resource definition for the web service." +
+                        " The maximum length of the pipeline name is eight characters",
+                    WSBIND: "The file name of the web service binding file on HFS.",
+                    DESCRIPTION: "Description of the web service resource being defined.",
+                    VALIDATION: "Specifies whether full validation of SOAP messages against the corresponding schema in the web service " +
+                        "description should be performed at run time.",
+                    WSDLFILE: "The file name of the web service description (WSDL) file on HFS.",
+                    REGIONNAME: "The CICS region name to which to define the new web service.",
+                    CICSPLEX: "The name of the CICSPlex to which to define the new web service."
+                },
+                MESSAGES: {
+                    SUCCESS: "The WEBSERVICE '%s' was defined successfully."
+                },
+                EXAMPLES: {
+                    EX1: "Define a webservice named WEBSVCA for the pipeline named PIPE123 to the region named MYREGION " +
+                        "in the CSD group MYGRP where the binding file is /u/exampleapp/wsbind/example.log"
+                }
             }
         }
     },

--- a/src/cli/define/Define.definition.ts
+++ b/src/cli/define/Define.definition.ts
@@ -10,15 +10,16 @@
 */
 
 import { ICommandDefinition } from "@zowe/imperative";
-import { ProgramDefinition } from "./program/Program.definition";
-
-import i18nTypings from "../-strings-/en";
-import { TransactionDefinition } from "./transaction/Transaction.definition";
 import { CicsSession } from "../CicsSession";
 
+import { ProgramDefinition } from "./program/Program.definition";
+import { TransactionDefinition } from "./transaction/Transaction.definition";
 import { UrimapServerDefinition } from "./urimap-server/UrimapServer.definition";
 import { UrimapClientDefinition } from "./urimap-client/UrimapClient.definition";
 import { UrimapPipelineDefinition } from "./urimap-pipeline/UrimapPipeline.definition";
+import { WebServiceDefinition } from "./webservice/Webservice.definition";
+
+import i18nTypings from "../-strings-/en";
 
 // Does not use the import in anticipation of some internationalization work to be done later.
 const strings = (require("../-strings-/en").default as typeof i18nTypings).DEFINE;
@@ -35,7 +36,8 @@ const definition: ICommandDefinition = {
                TransactionDefinition,
                UrimapServerDefinition,
                UrimapClientDefinition,
-               UrimapPipelineDefinition],
+               UrimapPipelineDefinition,
+               WebServiceDefinition],
     passOn: [
         {
             property: "options",

--- a/src/cli/define/webservice/Webservice.definition.ts
+++ b/src/cli/define/webservice/Webservice.definition.ts
@@ -1,0 +1,83 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { ICommandDefinition } from "@zowe/imperative";
+
+import i18nTypings from "../../-strings-/en";
+
+// Does not use the import in anticipation of some internationalization work to be done later.
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.WEBSERVICE;
+
+export const WebServiceDefinition: ICommandDefinition = {
+    name: "webservice",
+    aliases: ["web"],
+    description: strings.DESCRIPTION,
+    handler: __dirname + "/Webservice.handler",
+    type: "command",
+    positionals: [{
+        name: "webserviceName",
+        description: strings.POSITIONALS.WEBSERVICENAME,
+        type: "string",
+        required: true
+    }, {
+        name: "csdGroup",
+        description: strings.POSITIONALS.CSDGROUP,
+        type: "string",
+        required: true
+    }],
+    options: [
+        {
+            name: "pipeline-name",
+            aliases: ["pn"],
+            description: strings.OPTIONS.PIPELINENAME,
+            type: "string",
+            required: true
+        },
+        {
+            name: "wsbind",
+            description: strings.OPTIONS.WSBIND,
+            type: "string",
+            required: true
+        },
+        {
+            name: "description",
+            aliases: ["desc"],
+            description: strings.OPTIONS.DESCRIPTION,
+            type: "string"
+        },
+        {
+            name: "validation",
+            description: strings.OPTIONS.VALIDATION,
+            type: "boolean",
+            defaultValue: false
+        },
+        {
+            name: "wsdlfile",
+            aliases: ["wsdl"],
+            description: strings.OPTIONS.WSDLFILE,
+            type: "string"
+        },
+        {
+            name: "region-name",
+            description: strings.OPTIONS.REGIONNAME,
+            type: "string"
+        },
+        {
+            name: "cics-plex",
+            description: strings.OPTIONS.CICSPLEX,
+            type: "string"
+        }],
+    profile: {optional: ["cics"]},
+    examples: [{
+        description: strings.EXAMPLES.EX1,
+        options: "WEBSVCA MYGRP --pipeline-name PIPELINE --wsbind /u/exampleapp/wsbind/example.log --region-name MYREGION"
+    }]
+};

--- a/src/cli/define/webservice/Webservice.handler.ts
+++ b/src/cli/define/webservice/Webservice.handler.ts
@@ -34,11 +34,24 @@ export default class WebServiceHandler extends CicsBaseHandler {
         };
         params.response.progress.startBar({task: status});
 
+        /*
+        * Git Bash on Windows attempts to replace forward slashes with a
+        * directory path (e.g., /u -> U:/). CICS is picky when it validates the
+        * wsbind path. Unlike typical Unix paths, it must start with one slash
+        * and two are not allowed. We need to support paths prefixed with two
+        * slashes so Git Bash does not tamper with them, and then strip off the
+        * extra leading slash here so CICS validation will not complain.
+        */
+        let wsBind: string = params.arguments.wsbind;
+        if (wsBind.startsWith("//")) {
+            wsBind = wsBind.slice(1);
+        }
+
         const response = await defineWebservice(session, {
             name: params.arguments.webserviceName,
             csdGroup: params.arguments.csdGroup,
             pipelineName: params.arguments.pipelineName,
-            wsBind: params.arguments.wsbind,
+            wsBind,
             description: params.arguments.description,
             validation: params.arguments.validation,
             wsdlFile: params.arguments.wsdlFile,

--- a/src/cli/define/webservice/Webservice.handler.ts
+++ b/src/cli/define/webservice/Webservice.handler.ts
@@ -1,0 +1,52 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { AbstractSession, ICommandHandler, IHandlerParameters, IProfile, ITaskWithStatus, TaskStage } from "@zowe/imperative";
+import { defineTransaction, ICMCIApiResponse, defineWebservice } from "../../../api";
+import { CicsBaseHandler } from "../../CicsBaseHandler";
+
+import i18nTypings from "../../-strings-/en";
+
+// Does not use the import in anticipation of some internationalization work to be done later.
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.WEBSERVICE;
+
+/**
+ * Command handler for defining CICS transactions via CMCI
+ * @export
+ * @class TransactionHandler
+ * @implements {ICommandHandler}
+ */
+export default class WebServiceHandler extends CicsBaseHandler {
+    public async processWithSession(params: IHandlerParameters, session: AbstractSession, profile: IProfile): Promise<ICMCIApiResponse> {
+
+        const status: ITaskWithStatus = {
+            statusMessage: "Defining web service to CICS",
+            percentComplete: 0,
+            stageName: TaskStage.IN_PROGRESS
+        };
+        params.response.progress.startBar({task: status});
+
+        const response = await defineWebservice(session, {
+            name: params.arguments.webserviceName,
+            csdGroup: params.arguments.csdGroup,
+            pipeline: params.arguments.pipelineName,
+            wsBind: params.arguments.wsbind,
+            description: params.arguments.description,
+            validation: params.arguments.validation,
+            wsdlFile: params.arguments.wsdlFile,
+            regionName: params.arguments.regionName || profile.regionName,
+            cicsPlex: params.arguments.cicsPlex || profile.cicsPlex
+        });
+
+        params.response.console.log(strings.MESSAGES.SUCCESS, params.arguments.webserviceName);
+        return response;
+    }
+}

--- a/src/cli/define/webservice/Webservice.handler.ts
+++ b/src/cli/define/webservice/Webservice.handler.ts
@@ -37,7 +37,7 @@ export default class WebServiceHandler extends CicsBaseHandler {
         const response = await defineWebservice(session, {
             name: params.arguments.webserviceName,
             csdGroup: params.arguments.csdGroup,
-            pipeline: params.arguments.pipelineName,
+            pipelineName: params.arguments.pipelineName,
             wsBind: params.arguments.wsbind,
             description: params.arguments.description,
             validation: params.arguments.validation,


### PR DESCRIPTION
Resolves #58. Help text below.

```
$ zowe cics define webservice -h

 COMMAND NAME
 ------------

   webservice | web

 DESCRIPTION
 -----------

   Define a new web service to CICS.

 USAGE
 -----

   zowe cics define webservice <webserviceName> <csdGroup> [options]

 POSITIONAL ARGUMENTS
 --------------------

   webserviceName                (string)

      The name of the WEBSERVICE to create. The maximum length of the web service name
      is eight characters.

   csdGroup              (string)

      The CICS system definition (CSD) Group for the new web service that you want to
      define. The maximum length of the group name is eight characters.

 REQUIRED OPTIONS
 ----------------

   --pipeline-name  | --pn (string)

      The name of the PIPELINE resource definition for the web service. The maximum
      length of the pipeline name is eight characters

   --wsbind  (string)

      The file name of the web service binding file on HFS.

 OPTIONS
 -------

   --description  | --desc (string)

      Description of the web service resource being defined.

   --validation  (boolean)

      Specifies whether full validation of SOAP messages against the corresponding
      schema in the web service description should be performed at run time.

   --wsdlfile  | --wsdl (string)

      The file name of the web service description (WSDL) file on HFS.

   --region-name  (string)

      The CICS region name to which to define the new web service.

   --cics-plex  (string)

      The name of the CICSPlex to which to define the new web service.

 CICS CONNECTION OPTIONS
 -----------------------

   --host  | -H (string)

      The CICS server host name.

   --port  | -P (number)

      The CICS server port.

      Default value: 443

   --user  | -u (string)

      Mainframe (CICS) user name, which can be the same as your TSO login.

   --password  | --pw (string)

      Mainframe (CICS) password, which can be the same as your TSO password.

   --reject-unauthorized  | --ru (boolean)

      Reject self-signed certificates.

      Default value: true

   --protocol  | -o (string)

      Specifies CMCI protocol (http or https).

      Default value: http
      Allowed values: http, https

 PROFILE OPTIONS
 ---------------

   --cics-profile  | --cics-p (string)

      The name of a (cics) profile to load for this command execution.

 GLOBAL OPTIONS
 --------------

   --response-format-json  | --rfj (boolean)

      Produce JSON formatted data from a command

   --help  | -h (boolean)

      Display help text

   --help-examples  (boolean)

      Display examples for all the commands in a the group

   --help-web  | --hw (boolean)

      Display HTML help in browser

 EXAMPLES
 --------

   - Define a webservice named WEBSVCA for the pipeline named
   PIPE123 to the region named MYREGION in the CSD group MYGRP where the binding
   file is /u/exampleapp/wsbind/example.log:

      $ zowe cics define webservice WEBSVCA MYGRP --pipeline-name PIPELINE --wsbind /u/exampleapp/wsbind/example.log --region-name MYREGION
```