### PR TITLE
Add options for associating pipeline URIMaps with webservices

### DIFF
--- a/__tests__/__system__/cli/define/urimap-client/__snapshots__/cli.define.urimap.client.system.test.ts.snap
+++ b/__tests__/__system__/cli/define/urimap-client/__snapshots__/cli.define.urimap.client.system.test.ts.snap
@@ -35,29 +35,33 @@ exports[`CICS define urimap-client command should be able to display the help 1`
 
    --urimap-path  | --up (string)
 
-      The path component of the URI
+      The path component of the URI.
 
    --urimap-host  | --uh (string)
 
-      The host component of the URI
+      The host component of the URI.
 
  OPTIONS
  -------
 
    --urimap-scheme  | --us (string)
 
-      The scheme component to be used with the request (http or https)
+      The scheme component to be used with the request (http or https).
 
       Default value: http
       Allowed values: http, https
 
+   --description  | --desc (string)
+
+      Description of the URIMAP resource being defined.
+
    --region-name  (string)
 
-      The CICS region name to which to define the new URIMAP
+      The CICS region name to which to define the new URIMAP.
 
    --cics-plex  (string)
 
-      The name of the CICSPlex to which to define the new URIMAP
+      The name of the CICSPlex to which to define the new URIMAP.
 
  CICS CONNECTION OPTIONS
  -----------------------

--- a/__tests__/__system__/cli/define/urimap-pipeline/__scripts__/define_urimap_pipeline_all_options.sh
+++ b/__tests__/__system__/cli/define/urimap-pipeline/__scripts__/define_urimap_pipeline_all_options.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e # fail the script if we get a non zero exit code
+
+urimap_name=$1
+csd_group=$2
+urimap_path=$3
+urimap_host=$4
+pipeline_name=$5
+region_name=$6
+description=$7
+transaction_name=$8
+webservice_name=$9
+
+zowe cics define urimap-pipeline "$urimap_name" "$csd_group" --urimap-path "$urimap_path" --urimap-host "$urimap_host" --pipeline-name "$pipeline_name" --region-name "$region_name" --description "$description" --transaction-name "$transaction_name" --webservice-name "$webservice_name"

--- a/__tests__/__system__/cli/define/urimap-pipeline/__snapshots__/cli.define.urimap.pipeline.system.test.ts.snap
+++ b/__tests__/__system__/cli/define/urimap-pipeline/__snapshots__/cli.define.urimap.pipeline.system.test.ts.snap
@@ -64,12 +64,12 @@ exports[`CICS define urimap-pipeline command should be able to display the help 
    --transaction-name  | --tn (string)
 
       The name of the TRANSACTION resource definition for the URIMAP. The maximum
-      length of the transaction name is eight characters.
+      length of the transaction name is four characters.
 
-   --webservice  | --wsn (string)
+   --webservice-name  | --wn (string)
 
       The name of the WEBSERVICE resource definition for the URIMAP. The maximum
-      length of the transaction name is eight characters.
+      length of the transaction name is 32 characters.
 
    --region-name  (string)
 

--- a/__tests__/__system__/cli/define/urimap-pipeline/__snapshots__/cli.define.urimap.pipeline.system.test.ts.snap
+++ b/__tests__/__system__/cli/define/urimap-pipeline/__snapshots__/cli.define.urimap.pipeline.system.test.ts.snap
@@ -36,34 +36,48 @@ exports[`CICS define urimap-pipeline command should be able to display the help 
 
    --urimap-path  | --up (string)
 
-      The path component of the URI
+      The path component of the URI.
 
    --urimap-host  | --uh (string)
 
-      The host component of the URI
+      The host component of the URI.
 
    --pipeline-name  | --pn (string)
 
-      The name of the PIPELINE resource definition for the web service. The maximum
-      length of the pipeline name is eight characters
+      The name of the PIPELINE resource definition for the URIMAP. The maximum length
+      of the pipeline name is eight characters.
 
  OPTIONS
  -------
 
    --urimap-scheme  | --us (string)
 
-      The scheme component to be used with the request (http or https)
+      The scheme component to be used with the request (http or https).
 
       Default value: http
       Allowed values: http, https
 
+   --description  | --desc (string)
+
+      Description of the URIMAP resource being defined.
+
+   --transaction-name  | --tn (string)
+
+      The name of the TRANSACTION resource definition for the URIMAP. The maximum
+      length of the transaction name is eight characters.
+
+   --webservice  | --wsn (string)
+
+      The name of the WEBSERVICE resource definition for the URIMAP. The maximum
+      length of the transaction name is eight characters.
+
    --region-name  (string)
 
-      The CICS region name to which to define the new URIMAP
+      The CICS region name to which to define the new URIMAP.
 
    --cics-plex  (string)
 
-      The name of the CICSPlex to which to define the new URIMAP
+      The name of the CICSPlex to which to define the new URIMAP.
 
  CICS CONNECTION OPTIONS
  -----------------------

--- a/__tests__/__system__/cli/define/urimap-pipeline/cli.define.urimap.pipeline.system.test.ts
+++ b/__tests__/__system__/cli/define/urimap-pipeline/cli.define.urimap.pipeline.system.test.ts
@@ -89,6 +89,36 @@ describe("CICS define urimap-pipeline command", () => {
         await deleteUrimap(session, options);
     });
 
+    it("should be able to successfully define a pipeline urimap with all options", async () => {
+        const urimapNameSuffixLength = 4;
+        const urimapName = "DFN" + generateRandomAlphaNumericString(urimapNameSuffixLength);
+        const description = "hi i am urimap";
+        const transactionName = "tTxn";
+        const webserviceName = "testWebService";
+        const options: IURIMapParms = { name: urimapName, csdGroup, regionName };
+        let output = runCliScript(__dirname + "/__scripts__/define_urimap_pipeline_all_options.sh", TEST_ENVIRONMENT,
+            [urimapName, csdGroup, "urimap/test/invalid.html", "www.example.com", "FAKEPIPE", regionName,
+            description, transactionName, webserviceName]);
+        let stderr = output.stderr.toString();
+        expect(stderr).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toContain("success");
+
+        output = runCliScript(__dirname + "/__scripts__/get_resource_urimap.sh", TEST_ENVIRONMENT,
+            [regionName,
+                csdGroup]);
+        stderr = output.stderr.toString();
+        expect(stderr).toEqual("");
+        expect(output.status).toEqual(0);
+        expect(output.stdout.toString()).toContain(urimapName);
+        expect(output.stdout.toString()).toContain("ENABLED");
+        expect(output.stdout.toString()).toContain(description);
+        expect(output.stdout.toString()).toContain(transactionName);
+        expect(output.stdout.toString()).toContain(webserviceName);
+
+        await deleteUrimap(session, options);
+    });
+
     it("should get a syntax error if urimap name is omitted", () => {
         const output = runCliScript(__dirname + "/__scripts__/define_urimap_pipeline.sh", TEST_ENVIRONMENT,
             ["", "FAKEGRP", "FAKEPATH", "FAKEHOST", "FAKEPIPE", "FAKERGN"]);

--- a/__tests__/__system__/cli/define/urimap-server/__snapshots__/cli.define.urimap.server.system.test.ts.snap
+++ b/__tests__/__system__/cli/define/urimap-server/__snapshots__/cli.define.urimap.server.system.test.ts.snap
@@ -35,33 +35,37 @@ exports[`CICS define urimap-server command should be able to display the help 1`
 
    --urimap-path  | --up (string)
 
-      The path component of the URI
+      The path component of the URI.
 
    --urimap-host  | --uh (string)
 
-      The host component of the URI
+      The host component of the URI.
 
    --program-name  | --pn (string)
 
-      The application program that makes or handles the requests
+      The application program that makes or handles the requests.
 
  OPTIONS
  -------
 
    --urimap-scheme  | --us (string)
 
-      The scheme component to be used with the request (http or https)
+      The scheme component to be used with the request (http or https).
 
       Default value: http
       Allowed values: http, https
 
+   --description  | --desc (string)
+
+      Description of the URIMAP resource being defined.
+
    --region-name  (string)
 
-      The CICS region name to which to define the new URIMAP
+      The CICS region name to which to define the new URIMAP.
 
    --cics-plex  (string)
 
-      The name of the CICSPlex to which to define the new URIMAP
+      The name of the CICSPlex to which to define the new URIMAP.
 
  CICS CONNECTION OPTIONS
  -----------------------

--- a/__tests__/api/methods/define/Define.urimap-pipeline.unit.test.ts
+++ b/__tests__/api/methods/define/Define.urimap-pipeline.unit.test.ts
@@ -23,6 +23,9 @@ describe("CMCI - Define pipeline URIMap", () => {
     const group = "group";
     const cicsPlex = "plex";
     const content = "This\nis\r\na\ntest";
+    const description = "description";
+    const transaction = "transaction";
+    const webservice = "webservice";
 
     const defineParms: IURIMapParms  = {
         regionName: region,
@@ -406,6 +409,23 @@ describe("CMCI - Define pipeline URIMap", () => {
             defineParms.cicsPlex = cicsPlex;
             endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex +"/" + region;
+
+            response = await defineUrimapPipeline(dummySession, defineParms);
+
+            // expect(response.success).toBe(true);
+            expect(response).toContain(content);
+            expect(defineSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+        });
+
+        it("should be able to define a URIMap with optional parameters specified", async () => {
+            defineParms.description = description;
+            defineParms.transactionName = transaction;
+            defineParms.webserviceName = webservice;
+            endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+                CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex +"/" + region;
+            requestBody.request.create.attributes.$.description = description;
+            requestBody.request.create.attributes.$.transaction = transaction;
+            requestBody.request.create.attributes.$.webservice = webservice;
 
             response = await defineUrimapPipeline(dummySession, defineParms);
 

--- a/__tests__/cli/define/urimap-client/__snapshots__/UrimapClient.definition.unit.test.ts.snap
+++ b/__tests__/cli/define/urimap-client/__snapshots__/UrimapClient.definition.unit.test.ts.snap
@@ -18,7 +18,7 @@ Object {
       "aliases": Array [
         "up",
       ],
-      "description": "The path component of the URI",
+      "description": "The path component of the URI.",
       "name": "urimap-path",
       "required": true,
       "type": "string",
@@ -27,7 +27,7 @@ Object {
       "aliases": Array [
         "uh",
       ],
-      "description": "The host component of the URI",
+      "description": "The host component of the URI.",
       "name": "urimap-host",
       "required": true,
       "type": "string",
@@ -44,17 +44,25 @@ Object {
         ],
       },
       "defaultValue": "http",
-      "description": "The scheme component to be used with the request (http or https)",
+      "description": "The scheme component to be used with the request (http or https).",
       "name": "urimap-scheme",
       "type": "string",
     },
     Object {
-      "description": "The CICS region name to which to define the new URIMAP",
+      "aliases": Array [
+        "desc",
+      ],
+      "description": "Description of the URIMAP resource being defined.",
+      "name": "description",
+      "type": "string",
+    },
+    Object {
+      "description": "The CICS region name to which to define the new URIMAP.",
       "name": "region-name",
       "type": "string",
     },
     Object {
-      "description": "The name of the CICSPlex to which to define the new URIMAP",
+      "description": "The name of the CICSPlex to which to define the new URIMAP.",
       "name": "cics-plex",
       "type": "string",
     },

--- a/__tests__/cli/define/urimap-pipeline/UrimapPipeline.handler.unit.test.ts
+++ b/__tests__/cli/define/urimap-pipeline/UrimapPipeline.handler.unit.test.ts
@@ -81,6 +81,9 @@ describe("DefineUrimapPipelineHandler", () => {
     const urimapPath = "testPath";
     const urimapScheme = "http";
     const cicsPlex = "testPlex";
+    const description = "description";
+    const transactionName = "testTransaction";
+    const webserviceName = "testWebservice";
 
     const defaultReturn: ICMCIApiResponse = {
         response: {
@@ -96,7 +99,7 @@ describe("DefineUrimapPipelineHandler", () => {
         functionSpy.mockImplementation(async () => defaultReturn);
     });
 
-    it("should call the defineUrimapPipeline api", async () => {
+    it("should call the defineUrimapPipeline api with required options specified", async () => {
         const handler = new UrimapPipelineHandler();
 
         const commandParameters = {...DEFAULT_PARAMETERS};
@@ -139,6 +142,61 @@ describe("DefineUrimapPipelineHandler", () => {
                 host: urimapHost,
                 pipelineName,
                 scheme: urimapScheme,
+                regionName,
+                cicsPlex
+            }
+        );
+    });
+
+    it("should call the defineUrimapPipeline api with all options specified", async () => {
+        const handler = new UrimapPipelineHandler();
+
+        const commandParameters = {...DEFAULT_PARAMETERS};
+        commandParameters.arguments = {
+            ...commandParameters.arguments,
+            urimapName,
+            csdGroup,
+            urimapPath,
+            urimapHost,
+            pipelineName,
+            urimapScheme,
+            description,
+            transactionName,
+            webserviceName,
+            regionName,
+            cicsPlex,
+            host,
+            port,
+            user,
+            password,
+            rejectUnauthorized,
+            protocol
+        };
+
+        await handler.process(commandParameters);
+
+        expect(functionSpy).toHaveBeenCalledTimes(1);
+        const testProfile = PROFILE_MAP.get("cics")[0];
+        expect(functionSpy).toHaveBeenCalledWith(
+            new Session({
+                type: "basic",
+                hostname: testProfile.host,
+                port: testProfile.port,
+                user: testProfile.user,
+                password: testProfile.password,
+                rejectUnauthorized,
+                protocol
+            }),
+            {
+                name: urimapName,
+                csdGroup,
+                path: urimapPath,
+                host: urimapHost,
+                pipelineName,
+                scheme: urimapScheme,
+                description,
+                transactionName,
+                webserviceName,
                 regionName,
                 cicsPlex
             }

--- a/__tests__/cli/define/urimap-pipeline/__snapshots__/UrimapPipeline.definition.unit.test.ts.snap
+++ b/__tests__/cli/define/urimap-pipeline/__snapshots__/UrimapPipeline.definition.unit.test.ts.snap
@@ -18,7 +18,7 @@ Object {
       "aliases": Array [
         "up",
       ],
-      "description": "The path component of the URI",
+      "description": "The path component of the URI.",
       "name": "urimap-path",
       "required": true,
       "type": "string",
@@ -27,7 +27,7 @@ Object {
       "aliases": Array [
         "uh",
       ],
-      "description": "The host component of the URI",
+      "description": "The host component of the URI.",
       "name": "urimap-host",
       "required": true,
       "type": "string",
@@ -44,7 +44,7 @@ Object {
         ],
       },
       "defaultValue": "http",
-      "description": "The scheme component to be used with the request (http or https)",
+      "description": "The scheme component to be used with the request (http or https).",
       "name": "urimap-scheme",
       "type": "string",
     },
@@ -52,18 +52,42 @@ Object {
       "aliases": Array [
         "pn",
       ],
-      "description": "The name of the PIPELINE resource definition for the web service. The maximum length of the pipeline name is eight characters",
+      "description": "The name of the PIPELINE resource definition for the URIMAP. The maximum length of the pipeline name is eight characters.",
       "name": "pipeline-name",
       "required": true,
       "type": "string",
     },
     Object {
-      "description": "The CICS region name to which to define the new URIMAP",
+      "aliases": Array [
+        "desc",
+      ],
+      "description": "Description of the URIMAP resource being defined.",
+      "name": "description",
+      "type": "string",
+    },
+    Object {
+      "aliases": Array [
+        "tn",
+      ],
+      "description": "The name of the TRANSACTION resource definition for the URIMAP. The maximum length of the transaction name is eight characters.",
+      "name": "transaction-name",
+      "type": "string",
+    },
+    Object {
+      "aliases": Array [
+        "wsn",
+      ],
+      "description": "The name of the WEBSERVICE resource definition for the URIMAP. The maximum length of the transaction name is eight characters.",
+      "name": "webservice",
+      "type": "string",
+    },
+    Object {
+      "description": "The CICS region name to which to define the new URIMAP.",
       "name": "region-name",
       "type": "string",
     },
     Object {
-      "description": "The name of the CICSPlex to which to define the new URIMAP",
+      "description": "The name of the CICSPlex to which to define the new URIMAP.",
       "name": "cics-plex",
       "type": "string",
     },

--- a/__tests__/cli/define/urimap-pipeline/__snapshots__/UrimapPipeline.definition.unit.test.ts.snap
+++ b/__tests__/cli/define/urimap-pipeline/__snapshots__/UrimapPipeline.definition.unit.test.ts.snap
@@ -69,16 +69,16 @@ Object {
       "aliases": Array [
         "tn",
       ],
-      "description": "The name of the TRANSACTION resource definition for the URIMAP. The maximum length of the transaction name is eight characters.",
+      "description": "The name of the TRANSACTION resource definition for the URIMAP. The maximum length of the transaction name is four characters.",
       "name": "transaction-name",
       "type": "string",
     },
     Object {
       "aliases": Array [
-        "wsn",
+        "wn",
       ],
-      "description": "The name of the WEBSERVICE resource definition for the URIMAP. The maximum length of the transaction name is eight characters.",
-      "name": "webservice",
+      "description": "The name of the WEBSERVICE resource definition for the URIMAP. The maximum length of the transaction name is 32 characters.",
+      "name": "webservice-name",
       "type": "string",
     },
     Object {

--- a/__tests__/cli/define/urimap-pipeline/__snapshots__/UrimapPipeline.handler.unit.test.ts.snap
+++ b/__tests__/cli/define/urimap-pipeline/__snapshots__/UrimapPipeline.handler.unit.test.ts.snap
@@ -1,8 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DefineUrimapPipelineHandler should call the defineUrimapPipeline api 1`] = `"The URIMAP '%s' was defined successfully."`;
+exports[`DefineUrimapPipelineHandler should call the defineUrimapPipeline api with all options specified 1`] = `"The URIMAP '%s' was defined successfully."`;
 
-exports[`DefineUrimapPipelineHandler should call the defineUrimapPipeline api 2`] = `
+exports[`DefineUrimapPipelineHandler should call the defineUrimapPipeline api with all options specified 2`] = `
+Object {
+  "response": Object {
+    "records": "testing",
+    "resultsummary": Object {
+      "api_response1": "1024",
+      "api_response2": "0",
+      "displayed_recordcount": "0",
+      "recordcount": "0",
+    },
+  },
+}
+`;
+
+exports[`DefineUrimapPipelineHandler should call the defineUrimapPipeline api with required options specified 1`] = `"The URIMAP '%s' was defined successfully."`;
+
+exports[`DefineUrimapPipelineHandler should call the defineUrimapPipeline api with required options specified 2`] = `
 Object {
   "response": Object {
     "records": "testing",

--- a/__tests__/cli/define/urimap-server/__snapshots__/UrimapServer.definition.unit.test.ts.snap
+++ b/__tests__/cli/define/urimap-server/__snapshots__/UrimapServer.definition.unit.test.ts.snap
@@ -18,7 +18,7 @@ Object {
       "aliases": Array [
         "up",
       ],
-      "description": "The path component of the URI",
+      "description": "The path component of the URI.",
       "name": "urimap-path",
       "required": true,
       "type": "string",
@@ -27,7 +27,7 @@ Object {
       "aliases": Array [
         "uh",
       ],
-      "description": "The host component of the URI",
+      "description": "The host component of the URI.",
       "name": "urimap-host",
       "required": true,
       "type": "string",
@@ -44,7 +44,7 @@ Object {
         ],
       },
       "defaultValue": "http",
-      "description": "The scheme component to be used with the request (http or https)",
+      "description": "The scheme component to be used with the request (http or https).",
       "name": "urimap-scheme",
       "type": "string",
     },
@@ -52,18 +52,26 @@ Object {
       "aliases": Array [
         "pn",
       ],
-      "description": "The application program that makes or handles the requests",
+      "description": "The application program that makes or handles the requests.",
       "name": "program-name",
       "required": true,
       "type": "string",
     },
     Object {
-      "description": "The CICS region name to which to define the new URIMAP",
+      "aliases": Array [
+        "desc",
+      ],
+      "description": "Description of the URIMAP resource being defined.",
+      "name": "description",
+      "type": "string",
+    },
+    Object {
+      "description": "The CICS region name to which to define the new URIMAP.",
       "name": "region-name",
       "type": "string",
     },
     Object {
-      "description": "The name of the CICSPlex to which to define the new URIMAP",
+      "description": "The name of the CICSPlex to which to define the new URIMAP.",
       "name": "cics-plex",
       "type": "string",
     },

--- a/src/api/doc/IURIMapParms.ts
+++ b/src/api/doc/IURIMapParms.ts
@@ -59,13 +59,13 @@ export interface IURIMapParms {
 
     /**
      * Transaction resource associated with the URIMap
-     * Only used for pipeline URIMaps, up to 8 characters long
+     * Only used for pipeline URIMaps, up to 4 characters long
      */
     transactionName?: string;
 
     /**
      * Web service resource associated with the URIMap
-     * Only used for pipeline URIMaps, up to 8 characters long
+     * Only used for pipeline URIMaps, up to 32 characters long
      */
     webserviceName?: string;
 

--- a/src/api/doc/IURIMapParms.ts
+++ b/src/api/doc/IURIMapParms.ts
@@ -53,6 +53,23 @@ export interface IURIMapParms {
     pipelineName?: string;
 
     /**
+     * Description text for the URIMap
+     */
+    description?: string;
+
+    /**
+     * Transaction resource associated with the URIMap
+     * Only used for pipeline URIMaps, up to 8 characters long
+     */
+    transactionName?: string;
+
+    /**
+     * Web service resource associated with the URIMap
+     * Only used for pipeline URIMaps, up to 8 characters long
+     */
+    webserviceName?: string;
+
+    /**
      * The name of the CICS region of the URIMap
      */
     regionName: string;

--- a/src/api/methods/define/Define.ts
+++ b/src/api/methods/define/Define.ts
@@ -210,6 +210,27 @@ function validateUrimapParms(parms: IURIMapParms) {
  * @param {string} usage - value of the usage attribute (server, client, or pipeline)
  */
 function buildUrimapRequestBody(parms: IURIMapParms, usage: "server" | "client" | "pipeline") {
+    const requestAttrs: any = {
+        name: parms.name,
+        csdgroup: parms.csdGroup,
+        path: parms.path,
+        host: parms.host,
+        scheme: parms.scheme,
+        usage
+    };
+
+    if (parms.description != null) {
+        requestAttrs.description = parms.description;
+    }
+
+    if (parms.transactionName != null) {
+        requestAttrs.transaction = parms.transactionName;
+    }
+
+    if (parms.webserviceName != null) {
+        requestAttrs.webservice = parms.webserviceName;
+    }
+
     return {
         request: {
             create: {
@@ -219,14 +240,7 @@ function buildUrimapRequestBody(parms: IURIMapParms, usage: "server" | "client" 
                     }
                 },
                 attributes: {
-                    $: {
-                        name: parms.name,
-                        csdgroup: parms.csdGroup,
-                        path: parms.path,
-                        host: parms.host,
-                        scheme: parms.scheme,
-                        usage
-                    }
+                    $: requestAttrs
                 }
             }
         }

--- a/src/cli/-strings-/en.ts
+++ b/src/cli/-strings-/en.ts
@@ -67,14 +67,19 @@ export default {
                         " The maximum length of the group name is eight characters."
                 },
                 OPTIONS: {
-                    URIMAPHOST: "The host component of the URI",
-                    URIMAPPATH: "The path component of the URI",
-                    URIMAPSCHEME: "The scheme component to be used with the request (http or https)",
-                    REGIONNAME: "The CICS region name to which to define the new URIMAP",
-                    CICSPLEX: "The name of the CICSPlex to which to define the new URIMAP",
-                    PROGRAMNAME: "The application program that makes or handles the requests",
-                    PIPELINENAME: "The name of the PIPELINE resource definition for the web service." +
-                        " The maximum length of the pipeline name is eight characters",
+                    URIMAPHOST: "The host component of the URI.",
+                    URIMAPPATH: "The path component of the URI.",
+                    URIMAPSCHEME: "The scheme component to be used with the request (http or https).",
+                    REGIONNAME: "The CICS region name to which to define the new URIMAP.",
+                    CICSPLEX: "The name of the CICSPlex to which to define the new URIMAP.",
+                    PROGRAMNAME: "The application program that makes or handles the requests.",
+                    PIPELINENAME: "The name of the PIPELINE resource definition for the URIMAP. " +
+                        "The maximum length of the pipeline name is eight characters.",
+                    DESCRIPTION: "Description of the URIMAP resource being defined.",
+                    TRANSACTIONNAME: "The name of the TRANSACTION resource definition for the URIMAP. " +
+                        "The maximum length of the transaction name is eight characters.",
+                    WEBSERVICENAME: "The name of the WEBSERVICE resource definition for the URIMAP. " +
+                        "The maximum length of the transaction name is eight characters."
                 },
                 MESSAGES: {
                     SUCCESS: "The URIMAP '%s' was defined successfully."

--- a/src/cli/-strings-/en.ts
+++ b/src/cli/-strings-/en.ts
@@ -77,9 +77,9 @@ export default {
                         "The maximum length of the pipeline name is eight characters.",
                     DESCRIPTION: "Description of the URIMAP resource being defined.",
                     TRANSACTIONNAME: "The name of the TRANSACTION resource definition for the URIMAP. " +
-                        "The maximum length of the transaction name is eight characters.",
+                        "The maximum length of the transaction name is four characters.",
                     WEBSERVICENAME: "The name of the WEBSERVICE resource definition for the URIMAP. " +
-                        "The maximum length of the transaction name is eight characters."
+                        "The maximum length of the transaction name is 32 characters."
                 },
                 MESSAGES: {
                     SUCCESS: "The URIMAP '%s' was defined successfully."

--- a/src/cli/define/urimap-client/UrimapClient.definition.ts
+++ b/src/cli/define/urimap-client/UrimapClient.definition.ts
@@ -57,6 +57,12 @@ export const UrimapClientDefinition: ICommandDefinition = {
             defaultValue: "http"
         },
         {
+            name: "description",
+            aliases: ["desc"],
+            description: strings.OPTIONS.DESCRIPTION,
+            type: "string"
+        },
+        {
             name: "region-name",
             description: strings.OPTIONS.REGIONNAME,
             type: "string",

--- a/src/cli/define/urimap-client/UrimapClient.handler.ts
+++ b/src/cli/define/urimap-client/UrimapClient.handler.ts
@@ -40,6 +40,7 @@ export default class UrimapClientHandler extends CicsBaseHandler {
             path: params.arguments.urimapPath,
             host: params.arguments.urimapHost,
             scheme: params.arguments.urimapScheme,
+            description: params.arguments.description,
             regionName: params.arguments.regionName || profile.regionName,
             cicsPlex: params.arguments.cicsPlex || profile.cicsPlex
         });

--- a/src/cli/define/urimap-pipeline/UrimapPipeline.definition.ts
+++ b/src/cli/define/urimap-pipeline/UrimapPipeline.definition.ts
@@ -64,6 +64,24 @@ export const UrimapPipelineDefinition: ICommandDefinition = {
             required: true
         },
         {
+            name: "description",
+            aliases: ["desc"],
+            description: strings.OPTIONS.DESCRIPTION,
+            type: "string"
+        },
+        {
+            name: "transaction-name",
+            aliases: ["tn"],
+            description: strings.OPTIONS.TRANSACTIONNAME,
+            type: "string"
+        },
+        {
+            name: "webservice",
+            aliases: ["wsn"],
+            description: strings.OPTIONS.WEBSERVICENAME,
+            type: "string"
+        },
+        {
             name: "region-name",
             description: strings.OPTIONS.REGIONNAME,
             type: "string",

--- a/src/cli/define/urimap-pipeline/UrimapPipeline.definition.ts
+++ b/src/cli/define/urimap-pipeline/UrimapPipeline.definition.ts
@@ -76,8 +76,8 @@ export const UrimapPipelineDefinition: ICommandDefinition = {
             type: "string"
         },
         {
-            name: "webservice",
-            aliases: ["wsn"],
+            name: "webservice-name",
+            aliases: ["wn"],
             description: strings.OPTIONS.WEBSERVICENAME,
             type: "string"
         },

--- a/src/cli/define/urimap-pipeline/UrimapPipeline.handler.ts
+++ b/src/cli/define/urimap-pipeline/UrimapPipeline.handler.ts
@@ -41,6 +41,9 @@ export default class UrimapPipelineHandler extends CicsBaseHandler {
             host: params.arguments.urimapHost,
             pipelineName: params.arguments.pipelineName,
             scheme: params.arguments.urimapScheme,
+            description: params.arguments.description,
+            transactionName: params.arguments.transactionName,
+            webserviceName: params.arguments.webserviceName,
             regionName: params.arguments.regionName || profile.regionName,
             cicsPlex: params.arguments.cicsPlex || profile.cicsPlex
         });

--- a/src/cli/define/urimap-server/UrimapServer.definition.ts
+++ b/src/cli/define/urimap-server/UrimapServer.definition.ts
@@ -64,6 +64,12 @@ export const UrimapServerDefinition: ICommandDefinition = {
             required: true
         },
         {
+            name: "description",
+            aliases: ["desc"],
+            description: strings.OPTIONS.DESCRIPTION,
+            type: "string"
+        },
+        {
             name: "region-name",
             description: strings.OPTIONS.REGIONNAME,
             type: "string",

--- a/src/cli/define/urimap-server/UrimapServer.handler.ts
+++ b/src/cli/define/urimap-server/UrimapServer.handler.ts
@@ -41,6 +41,7 @@ export default class UrimapServerHandler extends CicsBaseHandler {
             host: params.arguments.urimapHost,
             programName: params.arguments.programName,
             scheme: params.arguments.urimapScheme,
+            description: params.arguments.description,
             regionName: params.arguments.regionName || profile.regionName,
             cicsPlex: params.arguments.cicsPlex || profile.cicsPlex
         });


### PR DESCRIPTION
Resolves #56. Adds the following options to commands:
* define urimap-server - description
* define urimap-client - description
* define urimap-pipeline - description, transaction-name, webservice-name