### PR TITLE
Add install and discard URIMAPs, fix enable and disable URIMAPs

### DIFF
--- a/__tests__/__system__/api/methods/define/Define.urimap-client.system.test.ts
+++ b/__tests__/__system__/api/methods/define/Define.urimap-client.system.test.ts
@@ -20,6 +20,13 @@ let regionName: string;
 let csdGroup: string;
 let enable: boolean;
 let session: Session;
+let urimapName: string;
+
+function sleep(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const sleepTime = 4000;
 
 describe("CICS Define client URImap", () => {
 
@@ -32,7 +39,9 @@ describe("CICS Define client URImap", () => {
         csdGroup = testEnvironment.systemTestProperties.cmci.csdGroup;
         enable = false;
         regionName = testEnvironment.systemTestProperties.cmci.regionName;
+        const urimapNameSuffixLength = 4;
         const cmciProperties = await testEnvironment.systemTestProperties.cmci;
+        urimapName = "AAAA" + generateRandomAlphaNumericString(urimapNameSuffixLength);
 
         session = new Session({
             user: cmciProperties.user,
@@ -55,9 +64,6 @@ describe("CICS Define client URImap", () => {
         let error;
         let response;
 
-        const urimapNameSuffixLength = 4;
-        const urimapName = "AAAA" + generateRandomAlphaNumericString(urimapNameSuffixLength);
-
         options.name = urimapName;
         options.path = "fake";
         options.host = "fake";
@@ -75,15 +81,13 @@ describe("CICS Define client URImap", () => {
         expect(error).toBeFalsy();
         expect(response).toBeTruthy();
         expect(response.response.resultsummary.api_response1).toBe("1024");
+        await sleep(sleepTime);
         await deleteUrimap(session, options);
     });
 
     it("should fail to define a URIMap to CICS with invalid CICS region", async () => {
         let error;
         let response;
-
-        const urimapNameSuffixLength = 4;
-        const urimapName = "AAAA" + generateRandomAlphaNumericString(urimapNameSuffixLength);
 
         options.name = urimapName;
         options.path = "fake";
@@ -108,9 +112,6 @@ describe("CICS Define client URImap", () => {
         let error;
         let response;
 
-        const urimapNameSuffixLength = 4;
-        const urimapName = "AAAA" + generateRandomAlphaNumericString(urimapNameSuffixLength);
-
         options.name = urimapName;
         options.path = "fake";
         options.host = "fake";
@@ -129,6 +130,7 @@ describe("CICS Define client URImap", () => {
         expect(error).toBeFalsy();
         expect(response).toBeTruthy();
         response = null; // reset
+        await sleep(sleepTime);
 
         // define the same URIMap and validate duplicate error
         try {
@@ -141,6 +143,7 @@ describe("CICS Define client URImap", () => {
         expect(response).toBeFalsy();
         expect(error.message).toContain("Did not receive the expected response from CMCI REST API");
         expect(error.message).toContain("DUPRES");
+        await sleep(sleepTime);
         await deleteUrimap(session, options);
     });
 });

--- a/__tests__/__system__/api/methods/define/Define.urimap-client.system.test.ts
+++ b/__tests__/__system__/api/methods/define/Define.urimap-client.system.test.ts
@@ -18,6 +18,7 @@ import { defineUrimapClient, deleteUrimap, IURIMapParms, } from "../../../../../
 let testEnvironment: ITestEnvironment;
 let regionName: string;
 let csdGroup: string;
+let enable: boolean;
 let session: Session;
 
 describe("CICS Define client URImap", () => {
@@ -29,6 +30,7 @@ describe("CICS Define client URImap", () => {
             tempProfileTypes: ["cics"]
         });
         csdGroup = testEnvironment.systemTestProperties.cmci.csdGroup;
+        enable = false;
         regionName = testEnvironment.systemTestProperties.cmci.regionName;
         const cmciProperties = await testEnvironment.systemTestProperties.cmci;
 
@@ -61,6 +63,7 @@ describe("CICS Define client URImap", () => {
         options.host = "fake";
         options.scheme = "http";
         options.csdGroup = csdGroup;
+        options.enable = enable;
         options.regionName = regionName;
 
         try {
@@ -113,6 +116,7 @@ describe("CICS Define client URImap", () => {
         options.host = "fake";
         options.scheme = "http";
         options.csdGroup = csdGroup;
+        options.enable = enable;
         options.regionName = regionName;
 
         // define a URIMap to CICS

--- a/__tests__/__system__/api/methods/define/Define.urimap-pipeline.system.test.ts
+++ b/__tests__/__system__/api/methods/define/Define.urimap-pipeline.system.test.ts
@@ -20,6 +20,13 @@ let regionName: string;
 let csdGroup: string;
 let session: Session;
 let enable: boolean;
+let urimapName: string;
+
+function sleep(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const sleepTime = 4000;
 
 describe("CICS Define pipeline URImap", () => {
 
@@ -33,6 +40,8 @@ describe("CICS Define pipeline URImap", () => {
         regionName = testEnvironment.systemTestProperties.cmci.regionName;
         enable = false;
         const cmciProperties = await testEnvironment.systemTestProperties.cmci;
+        const urimapNameSuffixLength = 4;
+        urimapName = "AAAA" + generateRandomAlphaNumericString(urimapNameSuffixLength);
 
         session = new Session({
             user: cmciProperties.user,
@@ -55,9 +64,6 @@ describe("CICS Define pipeline URImap", () => {
         let error;
         let response;
 
-        const urimapNameSuffixLength = 4;
-        const urimapName = "AAAA" + generateRandomAlphaNumericString(urimapNameSuffixLength);
-
         options.name = urimapName;
         options.path = "fake";
         options.host = "fake";
@@ -76,15 +82,13 @@ describe("CICS Define pipeline URImap", () => {
         expect(error).toBeFalsy();
         expect(response).toBeTruthy();
         expect(response.response.resultsummary.api_response1).toBe("1024");
+        await sleep(sleepTime);
         await deleteUrimap(session, options);
     });
 
     it("should fail to define a URIMap to CICS with invalid CICS region", async () => {
         let error;
         let response;
-
-        const urimapNameSuffixLength = 4;
-        const urimapName = "AAAA" + generateRandomAlphaNumericString(urimapNameSuffixLength);
 
         options.name = urimapName;
         options.path = "fake";
@@ -110,9 +114,6 @@ describe("CICS Define pipeline URImap", () => {
         let error;
         let response;
 
-        const urimapNameSuffixLength = 4;
-        const urimapName = "AAAA" + generateRandomAlphaNumericString(urimapNameSuffixLength);
-
         options.name = urimapName;
         options.path = "fake";
         options.host = "fake";
@@ -132,6 +133,7 @@ describe("CICS Define pipeline URImap", () => {
         expect(error).toBeFalsy();
         expect(response).toBeTruthy();
         response = null; // reset
+        await sleep(sleepTime);
 
         // define the same URIMap and validate duplicate error
         try {
@@ -144,6 +146,7 @@ describe("CICS Define pipeline URImap", () => {
         expect(response).toBeFalsy();
         expect(error.message).toContain("Did not receive the expected response from CMCI REST API");
         expect(error.message).toContain("DUPRES");
+        await sleep(sleepTime);
         await deleteUrimap(session, options);
     });
 });

--- a/__tests__/__system__/api/methods/define/Define.urimap-pipeline.system.test.ts
+++ b/__tests__/__system__/api/methods/define/Define.urimap-pipeline.system.test.ts
@@ -19,6 +19,7 @@ let testEnvironment: ITestEnvironment;
 let regionName: string;
 let csdGroup: string;
 let session: Session;
+let enable: boolean;
 
 describe("CICS Define pipeline URImap", () => {
 
@@ -30,6 +31,7 @@ describe("CICS Define pipeline URImap", () => {
         });
         csdGroup = testEnvironment.systemTestProperties.cmci.csdGroup;
         regionName = testEnvironment.systemTestProperties.cmci.regionName;
+        enable = false;
         const cmciProperties = await testEnvironment.systemTestProperties.cmci;
 
         session = new Session({
@@ -62,6 +64,7 @@ describe("CICS Define pipeline URImap", () => {
         options.scheme = "http";
         options.pipelineName = "AAAA1234";
         options.csdGroup = csdGroup;
+        options.enable = enable;
         options.regionName = regionName;
 
         try {
@@ -116,6 +119,7 @@ describe("CICS Define pipeline URImap", () => {
         options.scheme = "http";
         options.pipelineName = "AAAA1234";
         options.csdGroup = csdGroup;
+        options.enable = enable;
         options.regionName = regionName;
 
         // define a URIMap to CICS

--- a/__tests__/__system__/api/methods/define/Define.urimap-server.system.test.ts
+++ b/__tests__/__system__/api/methods/define/Define.urimap-server.system.test.ts
@@ -20,6 +20,13 @@ let regionName: string;
 let csdGroup: string;
 let session: Session;
 let enable: boolean;
+let urimapName: string;
+
+function sleep(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const sleepTime = 4000;
 
 describe("CICS Define server URImap", () => {
 
@@ -33,6 +40,8 @@ describe("CICS Define server URImap", () => {
         enable = false;
         regionName = testEnvironment.systemTestProperties.cmci.regionName;
         const cmciProperties = await testEnvironment.systemTestProperties.cmci;
+        const urimapNameSuffixLength = 4;
+        urimapName = "AAAA" + generateRandomAlphaNumericString(urimapNameSuffixLength);
 
         session = new Session({
             user: cmciProperties.user,
@@ -55,9 +64,6 @@ describe("CICS Define server URImap", () => {
         let error;
         let response;
 
-        const urimapNameSuffixLength = 4;
-        const urimapName = "AAAA" + generateRandomAlphaNumericString(urimapNameSuffixLength);
-
         options.name = urimapName;
         options.path = "fake";
         options.host = "fake";
@@ -76,15 +82,13 @@ describe("CICS Define server URImap", () => {
         expect(error).toBeFalsy();
         expect(response).toBeTruthy();
         expect(response.response.resultsummary.api_response1).toBe("1024");
+        await sleep(sleepTime);
         await deleteUrimap(session, options);
     });
 
     it("should fail to define a URIMap to CICS with invalid CICS region", async () => {
         let error;
         let response;
-
-        const urimapNameSuffixLength = 4;
-        const urimapName = "AAAA" + generateRandomAlphaNumericString(urimapNameSuffixLength);
 
         options.name = urimapName;
         options.path = "fake";
@@ -110,9 +114,6 @@ describe("CICS Define server URImap", () => {
         let error;
         let response;
 
-        const urimapNameSuffixLength = 4;
-        const urimapName = "AAAA" + generateRandomAlphaNumericString(urimapNameSuffixLength);
-
         options.name = urimapName;
         options.path = "fake";
         options.host = "fake";
@@ -132,6 +133,7 @@ describe("CICS Define server URImap", () => {
         expect(error).toBeFalsy();
         expect(response).toBeTruthy();
         response = null; // reset
+        await sleep(sleepTime);
 
         // define the same URIMap and validate duplicate error
         try {
@@ -144,6 +146,7 @@ describe("CICS Define server URImap", () => {
         expect(response).toBeFalsy();
         expect(error.message).toContain("Did not receive the expected response from CMCI REST API");
         expect(error.message).toContain("DUPRES");
+        await sleep(sleepTime);
         await deleteUrimap(session, options);
     });
 });

--- a/__tests__/__system__/api/methods/define/Define.urimap-server.system.test.ts
+++ b/__tests__/__system__/api/methods/define/Define.urimap-server.system.test.ts
@@ -19,6 +19,7 @@ let testEnvironment: ITestEnvironment;
 let regionName: string;
 let csdGroup: string;
 let session: Session;
+let enable: boolean;
 
 describe("CICS Define server URImap", () => {
 
@@ -29,6 +30,7 @@ describe("CICS Define server URImap", () => {
             tempProfileTypes: ["cics"]
         });
         csdGroup = testEnvironment.systemTestProperties.cmci.csdGroup;
+        enable = false;
         regionName = testEnvironment.systemTestProperties.cmci.regionName;
         const cmciProperties = await testEnvironment.systemTestProperties.cmci;
 
@@ -62,6 +64,7 @@ describe("CICS Define server URImap", () => {
         options.scheme = "http";
         options.programName = "AAAA1234";
         options.csdGroup = csdGroup;
+        options.enable = enable;
         options.regionName = regionName;
 
         try {
@@ -116,6 +119,7 @@ describe("CICS Define server URImap", () => {
         options.scheme = "http";
         options.programName = "AAAA1234";
         options.csdGroup = csdGroup;
+        options.enable = enable;
         options.regionName = regionName;
 
         // define a URIMap to CICS

--- a/__tests__/__system__/api/methods/disable/Disable.urimap.system.test.ts
+++ b/__tests__/__system__/api/methods/disable/Disable.urimap.system.test.ts
@@ -13,7 +13,8 @@ import { Session, selectProfileNameDesc } from "@zowe/imperative";
 import { ITestEnvironment } from "../../../../__src__/environment/doc/response/ITestEnvironment";
 import { TestEnvironment } from "../../../../__src__/environment/TestEnvironment";
 import { generateRandomAlphaNumericString } from "../../../../__src__/TestUtils";
-import { defineUrimapServer, defineUrimapClient, defineUrimapPipeline, deleteUrimap, disableUrimap, IURIMapParms } from "../../../../../src";
+import { defineUrimapServer, defineUrimapClient, defineUrimapPipeline, deleteUrimap, disableUrimap, IURIMapParms, discardUrimap,
+         installUrimap, enableUrimap } from "../../../../../src";
 
 let testEnvironment: ITestEnvironment;
 let regionName: string;
@@ -71,6 +72,10 @@ describe("CICS Disable URImap", () => {
         options.regionName = regionName;
         await defineUrimapServer(session, options);
         await sleep(sleepTime);
+        await installUrimap(session, options);
+        await sleep(sleepTime);
+        await enableUrimap(session, options);
+        await sleep(sleepTime);
 
         try {
             response = await disableUrimap(session, options);
@@ -81,6 +86,8 @@ describe("CICS Disable URImap", () => {
         expect(error).toBeFalsy();
         expect(response).toBeTruthy();
         expect(response.response.resultsummary.api_response1).toBe("1024");
+        await sleep(sleepTime);
+        await discardUrimap(session, options);
         await sleep(sleepTime);
         await deleteUrimap(session, options);
     });
@@ -99,7 +106,11 @@ describe("CICS Disable URImap", () => {
         options.pipelineName = "AAAB1234";
         options.csdGroup = csdGroup;
         options.regionName = regionName;
-        await defineUrimapPipeline(session, options);
+        await defineUrimapServer(session, options);
+        await sleep(sleepTime);
+        await installUrimap(session, options);
+        await sleep(sleepTime);
+        await enableUrimap(session, options);
         await sleep(sleepTime);
 
         try {
@@ -111,6 +122,8 @@ describe("CICS Disable URImap", () => {
         expect(error).toBeFalsy();
         expect(response).toBeTruthy();
         expect(response.response.resultsummary.api_response1).toBe("1024");
+        await sleep(sleepTime);
+        await discardUrimap(session, options);
         await sleep(sleepTime);
         await deleteUrimap(session, options);
     });
@@ -128,7 +141,11 @@ describe("CICS Disable URImap", () => {
         options.scheme = "http";
         options.csdGroup = csdGroup;
         options.regionName = regionName;
-        await defineUrimapClient(session, options);
+        await defineUrimapServer(session, options);
+        await sleep(sleepTime);
+        await installUrimap(session, options);
+        await sleep(sleepTime);
+        await enableUrimap(session, options);
         await sleep(sleepTime);
 
         try {
@@ -140,6 +157,8 @@ describe("CICS Disable URImap", () => {
         expect(error).toBeFalsy();
         expect(response).toBeTruthy();
         expect(response.response.resultsummary.api_response1).toBe("1024");
+        await sleep(sleepTime);
+        await discardUrimap(session, options);
         await sleep(sleepTime);
         await deleteUrimap(session, options);
     });

--- a/__tests__/__system__/api/methods/disable/Disable.urimap.system.test.ts
+++ b/__tests__/__system__/api/methods/disable/Disable.urimap.system.test.ts
@@ -106,7 +106,7 @@ describe("CICS Disable URImap", () => {
         options.pipelineName = "AAAB1234";
         options.csdGroup = csdGroup;
         options.regionName = regionName;
-        await defineUrimapServer(session, options);
+        await defineUrimapPipeline(session, options);
         await sleep(sleepTime);
         await installUrimap(session, options);
         await sleep(sleepTime);
@@ -141,7 +141,7 @@ describe("CICS Disable URImap", () => {
         options.scheme = "http";
         options.csdGroup = csdGroup;
         options.regionName = regionName;
-        await defineUrimapServer(session, options);
+        await defineUrimapClient(session, options);
         await sleep(sleepTime);
         await installUrimap(session, options);
         await sleep(sleepTime);

--- a/__tests__/__system__/api/methods/discard/Discard.urimap.system.test.ts
+++ b/__tests__/__system__/api/methods/discard/Discard.urimap.system.test.ts
@@ -24,7 +24,7 @@ function sleep(ms: number) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-const sleepTime = 2000;
+const sleepTime = 5000;
 
 describe("CICS Discard URImap", () => {
 
@@ -69,6 +69,7 @@ describe("CICS Discard URImap", () => {
         options.programName = "AAAA1234";
         options.csdGroup = csdGroup;
         options.regionName = regionName;
+        options.enable = false;
         await defineUrimapServer(session, options);
         await sleep(sleepTime);
         await installUrimap(session, options);
@@ -101,10 +102,11 @@ describe("CICS Discard URImap", () => {
         options.pipelineName = "AAAB1234";
         options.csdGroup = csdGroup;
         options.regionName = regionName;
+        options.enable = false;
         await defineUrimapServer(session, options);
         await sleep(sleepTime);
         await installUrimap(session, options);
-        await sleep(2*sleepTime);
+        await sleep(sleepTime);
 
         try {
             response = await discardUrimap(session, options);
@@ -132,10 +134,11 @@ describe("CICS Discard URImap", () => {
         options.scheme = "http";
         options.csdGroup = csdGroup;
         options.regionName = regionName;
+        options.enable = false;
         await defineUrimapServer(session, options);
         await sleep(sleepTime);
         await installUrimap(session, options);
-        await sleep(2*sleepTime);
+        await sleep(sleepTime);
 
         try {
             response = await discardUrimap(session, options);

--- a/__tests__/__system__/api/methods/discard/Discard.urimap.system.test.ts
+++ b/__tests__/__system__/api/methods/discard/Discard.urimap.system.test.ts
@@ -103,7 +103,7 @@ describe("CICS Discard URImap", () => {
         options.csdGroup = csdGroup;
         options.regionName = regionName;
         options.enable = false;
-        await defineUrimapServer(session, options);
+        await defineUrimapPipeline(session, options);
         await sleep(sleepTime);
         await installUrimap(session, options);
         await sleep(sleepTime);
@@ -135,7 +135,7 @@ describe("CICS Discard URImap", () => {
         options.csdGroup = csdGroup;
         options.regionName = regionName;
         options.enable = false;
-        await defineUrimapServer(session, options);
+        await defineUrimapClient(session, options);
         await sleep(sleepTime);
         await installUrimap(session, options);
         await sleep(sleepTime);

--- a/__tests__/__system__/api/methods/discard/Discard.urimap.system.test.ts
+++ b/__tests__/__system__/api/methods/discard/Discard.urimap.system.test.ts
@@ -9,12 +9,11 @@
 *                                                                                 *
 */
 
-import { Session } from "@zowe/imperative";
+import { Session, selectProfileNameDesc } from "@zowe/imperative";
 import { ITestEnvironment } from "../../../../__src__/environment/doc/response/ITestEnvironment";
 import { TestEnvironment } from "../../../../__src__/environment/TestEnvironment";
 import { generateRandomAlphaNumericString } from "../../../../__src__/TestUtils";
-import { defineUrimapServer, defineUrimapClient, defineUrimapPipeline, deleteUrimap, disableUrimap, IURIMapParms, enableUrimap, discardUrimap,
-         installUrimap } from "../../../../../src";
+import { defineUrimapServer, defineUrimapClient, defineUrimapPipeline, deleteUrimap, IURIMapParms, discardUrimap, installUrimap, disableUrimap } from "../../../../../src";
 
 let testEnvironment: ITestEnvironment;
 let regionName: string;
@@ -27,11 +26,11 @@ function sleep(ms: number) {
 
 const sleepTime = 2000;
 
-describe("CICS Enable URImap", () => {
+describe("CICS Discard URImap", () => {
 
     beforeAll(async () => {
         testEnvironment = await TestEnvironment.setUp({
-            testName: "cics_cmci_enable_urimap",
+            testName: "cics_cmci_discard_urimap",
             installPlugin: true,
             tempProfileTypes: ["cics"]
         });
@@ -56,7 +55,7 @@ describe("CICS Enable URImap", () => {
 
     const options: IURIMapParms = {} as any;
 
-    it("should enable a URIMap of type server from CICS", async () => {
+    it("should discard a URIMap of type server from CICS", async () => {
         let error;
         let response;
 
@@ -76,7 +75,7 @@ describe("CICS Enable URImap", () => {
         await sleep(sleepTime);
 
         try {
-            response = await enableUrimap(session, options);
+            response = await discardUrimap(session, options);
         } catch (err) {
             error = err;
         }
@@ -85,14 +84,10 @@ describe("CICS Enable URImap", () => {
         expect(response).toBeTruthy();
         expect(response.response.resultsummary.api_response1).toBe("1024");
         await sleep(sleepTime);
-        await disableUrimap(session, options);
-        await sleep(sleepTime);
-        await discardUrimap(session, options);
-        await sleep(sleepTime);
         await deleteUrimap(session, options);
     });
 
-    it("should enable a URIMap of type pipeline from CICS", async () => {
+    it("should discard a URIMap of type pipeline from CICS", async () => {
         let error;
         let response;
 
@@ -109,10 +104,10 @@ describe("CICS Enable URImap", () => {
         await defineUrimapServer(session, options);
         await sleep(sleepTime);
         await installUrimap(session, options);
-        await sleep(sleepTime);
+        await sleep(2*sleepTime);
 
         try {
-            response = await enableUrimap(session, options);
+            response = await discardUrimap(session, options);
         } catch (err) {
             error = err;
         }
@@ -121,14 +116,10 @@ describe("CICS Enable URImap", () => {
         expect(response).toBeTruthy();
         expect(response.response.resultsummary.api_response1).toBe("1024");
         await sleep(sleepTime);
-        await disableUrimap(session, options);
-        await sleep(sleepTime);
-        await discardUrimap(session, options);
-        await sleep(sleepTime);
         await deleteUrimap(session, options);
     });
 
-    it("should enable a URIMap of type client from CICS", async () => {
+    it("should discard a URIMap of type client from CICS", async () => {
         let error;
         let response;
 
@@ -144,10 +135,10 @@ describe("CICS Enable URImap", () => {
         await defineUrimapServer(session, options);
         await sleep(sleepTime);
         await installUrimap(session, options);
-        await sleep(sleepTime);
+        await sleep(2*sleepTime);
 
         try {
-            response = await enableUrimap(session, options);
+            response = await discardUrimap(session, options);
         } catch (err) {
             error = err;
         }
@@ -156,14 +147,10 @@ describe("CICS Enable URImap", () => {
         expect(response).toBeTruthy();
         expect(response.response.resultsummary.api_response1).toBe("1024");
         await sleep(sleepTime);
-        await disableUrimap(session, options);
-        await sleep(sleepTime);
-        await discardUrimap(session, options);
-        await sleep(sleepTime);
         await deleteUrimap(session, options);
     });
 
-    it("should fail to enable a URIMap to CICS with invalid CICS region", async () => {
+    it("should fail to discard a URIMap to CICS with invalid CICS region", async () => {
         let error;
         let response;
 
@@ -178,7 +165,7 @@ describe("CICS Enable URImap", () => {
         options.regionName = "fake";
 
         try {
-            response = await enableUrimap(session, options);
+            response = await discardUrimap(session, options);
         } catch (err) {
             error = err;
         }
@@ -189,7 +176,7 @@ describe("CICS Enable URImap", () => {
         expect(error.message).toContain("INVALIDPARM");
     });
 
-    it("should fail to enable a URIMap that does not exist", async () => {
+    it("should fail to discard a URIMap that does not exist", async () => {
         let error;
         let response;
 
@@ -203,7 +190,7 @@ describe("CICS Enable URImap", () => {
         options.regionName = regionName;
 
         try {
-            response = await enableUrimap(session, options);
+            response = await discardUrimap(session, options);
         } catch (err) {
             error = err;
         }

--- a/__tests__/__system__/api/methods/enable/Enable.urimap.system.test.ts
+++ b/__tests__/__system__/api/methods/enable/Enable.urimap.system.test.ts
@@ -106,7 +106,7 @@ describe("CICS Enable URImap", () => {
         options.pipelineName = "AAAB1234";
         options.csdGroup = csdGroup;
         options.regionName = regionName;
-        await defineUrimapServer(session, options);
+        await defineUrimapPipeline(session, options);
         await sleep(sleepTime);
         await installUrimap(session, options);
         await sleep(sleepTime);
@@ -141,7 +141,7 @@ describe("CICS Enable URImap", () => {
         options.scheme = "http";
         options.csdGroup = csdGroup;
         options.regionName = regionName;
-        await defineUrimapServer(session, options);
+        await defineUrimapClient(session, options);
         await sleep(sleepTime);
         await installUrimap(session, options);
         await sleep(sleepTime);

--- a/__tests__/__system__/api/methods/install/Install.urimap.system.test.ts
+++ b/__tests__/__system__/api/methods/install/Install.urimap.system.test.ts
@@ -70,6 +70,7 @@ describe("CICS Install URImap", () => {
         options.programName = "AAAA1234";
         options.csdGroup = csdGroup;
         options.regionName = regionName;
+        options.enable = false;
         await defineUrimapServer(session, options);
         await sleep(sleepTime);
 
@@ -99,9 +100,10 @@ describe("CICS Install URImap", () => {
         options.path = "fake";
         options.host = "fake";
         options.scheme = "http";
-        options.pipelineName = "AAAB1234";
+        options.pipelineName = "AAAB1235";
         options.csdGroup = csdGroup;
         options.regionName = regionName;
+        options.enable = false;
         await defineUrimapServer(session, options);
         await sleep(sleepTime);
 
@@ -133,6 +135,7 @@ describe("CICS Install URImap", () => {
         options.scheme = "http";
         options.csdGroup = csdGroup;
         options.regionName = regionName;
+        options.enable = false;
         await defineUrimapServer(session, options);
         await sleep(sleepTime);
 

--- a/__tests__/__system__/api/methods/install/Install.urimap.system.test.ts
+++ b/__tests__/__system__/api/methods/install/Install.urimap.system.test.ts
@@ -9,12 +9,12 @@
 *                                                                                 *
 */
 
-import { Session } from "@zowe/imperative";
+import { Session, selectProfileNameDesc } from "@zowe/imperative";
 import { ITestEnvironment } from "../../../../__src__/environment/doc/response/ITestEnvironment";
 import { TestEnvironment } from "../../../../__src__/environment/TestEnvironment";
 import { generateRandomAlphaNumericString } from "../../../../__src__/TestUtils";
-import { defineUrimapServer, defineUrimapClient, defineUrimapPipeline, deleteUrimap, disableUrimap, IURIMapParms, enableUrimap, discardUrimap,
-         installUrimap } from "../../../../../src";
+import { defineUrimapServer, defineUrimapClient, defineUrimapPipeline, deleteUrimap, disableUrimap, IURIMapParms, discardUrimap,
+         installUrimap, enableUrimap } from "../../../../../src";
 
 let testEnvironment: ITestEnvironment;
 let regionName: string;
@@ -27,11 +27,11 @@ function sleep(ms: number) {
 
 const sleepTime = 2000;
 
-describe("CICS Enable URImap", () => {
+describe("CICS Install URImap", () => {
 
     beforeAll(async () => {
         testEnvironment = await TestEnvironment.setUp({
-            testName: "cics_cmci_enable_urimap",
+            testName: "cics_cmci_install_urimap",
             installPlugin: true,
             tempProfileTypes: ["cics"]
         });
@@ -56,7 +56,7 @@ describe("CICS Enable URImap", () => {
 
     const options: IURIMapParms = {} as any;
 
-    it("should enable a URIMap of type server from CICS", async () => {
+    it("should install a URIMap of type server from CICS", async () => {
         let error;
         let response;
 
@@ -72,11 +72,9 @@ describe("CICS Enable URImap", () => {
         options.regionName = regionName;
         await defineUrimapServer(session, options);
         await sleep(sleepTime);
-        await installUrimap(session, options);
-        await sleep(sleepTime);
 
         try {
-            response = await enableUrimap(session, options);
+            response = await installUrimap(session, options);
         } catch (err) {
             error = err;
         }
@@ -85,14 +83,12 @@ describe("CICS Enable URImap", () => {
         expect(response).toBeTruthy();
         expect(response.response.resultsummary.api_response1).toBe("1024");
         await sleep(sleepTime);
-        await disableUrimap(session, options);
-        await sleep(sleepTime);
         await discardUrimap(session, options);
         await sleep(sleepTime);
         await deleteUrimap(session, options);
     });
 
-    it("should enable a URIMap of type pipeline from CICS", async () => {
+    it("should install a URIMap of type pipeline from CICS", async () => {
         let error;
         let response;
 
@@ -108,11 +104,9 @@ describe("CICS Enable URImap", () => {
         options.regionName = regionName;
         await defineUrimapServer(session, options);
         await sleep(sleepTime);
-        await installUrimap(session, options);
-        await sleep(sleepTime);
 
         try {
-            response = await enableUrimap(session, options);
+            response = await installUrimap(session, options);
         } catch (err) {
             error = err;
         }
@@ -121,14 +115,12 @@ describe("CICS Enable URImap", () => {
         expect(response).toBeTruthy();
         expect(response.response.resultsummary.api_response1).toBe("1024");
         await sleep(sleepTime);
-        await disableUrimap(session, options);
-        await sleep(sleepTime);
         await discardUrimap(session, options);
         await sleep(sleepTime);
         await deleteUrimap(session, options);
     });
 
-    it("should enable a URIMap of type client from CICS", async () => {
+    it("should install a URIMap of type client from CICS", async () => {
         let error;
         let response;
 
@@ -143,11 +135,9 @@ describe("CICS Enable URImap", () => {
         options.regionName = regionName;
         await defineUrimapServer(session, options);
         await sleep(sleepTime);
-        await installUrimap(session, options);
-        await sleep(sleepTime);
 
         try {
-            response = await enableUrimap(session, options);
+            response = await installUrimap(session, options);
         } catch (err) {
             error = err;
         }
@@ -156,14 +146,12 @@ describe("CICS Enable URImap", () => {
         expect(response).toBeTruthy();
         expect(response.response.resultsummary.api_response1).toBe("1024");
         await sleep(sleepTime);
-        await disableUrimap(session, options);
-        await sleep(sleepTime);
         await discardUrimap(session, options);
         await sleep(sleepTime);
         await deleteUrimap(session, options);
     });
 
-    it("should fail to enable a URIMap to CICS with invalid CICS region", async () => {
+    it("should fail to install a URIMap to CICS with invalid CICS region", async () => {
         let error;
         let response;
 
@@ -178,7 +166,7 @@ describe("CICS Enable URImap", () => {
         options.regionName = "fake";
 
         try {
-            response = await enableUrimap(session, options);
+            response = await installUrimap(session, options);
         } catch (err) {
             error = err;
         }
@@ -189,7 +177,7 @@ describe("CICS Enable URImap", () => {
         expect(error.message).toContain("INVALIDPARM");
     });
 
-    it("should fail to enable a URIMap that does not exist", async () => {
+    it("should fail to install a URIMap that does not exist", async () => {
         let error;
         let response;
 
@@ -203,7 +191,7 @@ describe("CICS Enable URImap", () => {
         options.regionName = regionName;
 
         try {
-            response = await enableUrimap(session, options);
+            response = await installUrimap(session, options);
         } catch (err) {
             error = err;
         }

--- a/__tests__/__system__/api/methods/install/Install.urimap.system.test.ts
+++ b/__tests__/__system__/api/methods/install/Install.urimap.system.test.ts
@@ -104,7 +104,7 @@ describe("CICS Install URImap", () => {
         options.csdGroup = csdGroup;
         options.regionName = regionName;
         options.enable = false;
-        await defineUrimapServer(session, options);
+        await defineUrimapPipeline(session, options);
         await sleep(sleepTime);
 
         try {
@@ -136,7 +136,7 @@ describe("CICS Install URImap", () => {
         options.csdGroup = csdGroup;
         options.regionName = regionName;
         options.enable = false;
-        await defineUrimapServer(session, options);
+        await defineUrimapClient(session, options);
         await sleep(sleepTime);
 
         try {

--- a/__tests__/__system__/cli/define/urimap-client/__scripts__/define_urimap_client.sh
+++ b/__tests__/__system__/cli/define/urimap-client/__scripts__/define_urimap_client.sh
@@ -7,4 +7,4 @@ urimap_path=$3
 urimap_host=$4
 region_name=$5
 
-zowe cics define urimap-client "$urimap_name" "$csd_group" --urimap-path "$urimap_path" --urimap-host "$urimap_host" --region-name "$region_name"
+zowe cics define urimap-client "$urimap_name" "$csd_group" --urimap-path "$urimap_path" --urimap-host "$urimap_host" --region-name "$region_name" --enable false

--- a/__tests__/__system__/cli/define/urimap-client/__scripts__/define_urimap_client_fully_qualified.sh
+++ b/__tests__/__system__/cli/define/urimap-client/__scripts__/define_urimap_client_fully_qualified.sh
@@ -13,4 +13,4 @@ USER=$9
 PASSWORD=${10}
 PROTOCOL=${11}
 REJECT=${12}
-zowe cics define urimap-client "$urimap_name" "$csd_group" --urimap-path "$urimap_path" --urimap-host "$urimap_host" --urimap-scheme "$urimap_scheme" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"
+zowe cics define urimap-client "$urimap_name" "$csd_group" --urimap-path "$urimap_path" --urimap-host "$urimap_host" --urimap-scheme "$urimap_scheme" --region-name "$region_name" --enable false --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"

--- a/__tests__/__system__/cli/define/urimap-client/__snapshots__/cli.define.urimap.client.system.test.ts.snap
+++ b/__tests__/__system__/cli/define/urimap-client/__snapshots__/cli.define.urimap.client.system.test.ts.snap
@@ -63,6 +63,12 @@ exports[`CICS define urimap-client command should be able to display the help 1`
 
       The name of the CICSPlex to which to define the new URIMAP.
 
+   --enable  (boolean)
+
+      Whether or not the URIMAP is to be enabled on install by default.
+
+      Default value: true
+
  CICS CONNECTION OPTIONS
  -----------------------
 

--- a/__tests__/__system__/cli/define/urimap-client/cli.define.urimap.client.system.test.ts
+++ b/__tests__/__system__/cli/define/urimap-client/cli.define.urimap.client.system.test.ts
@@ -28,6 +28,12 @@ let protocol: string;
 let rejectUnauthorized: boolean;
 let session: Session;
 
+function sleep(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const sleepTime = 2000;
+
 describe("CICS define urimap-client command", () => {
 
     beforeAll(async () => {
@@ -87,7 +93,9 @@ describe("CICS define urimap-client command", () => {
         expect(output.stdout.toString()).toContain(urimapName);
         expect(output.stdout.toString()).toContain("ENABLED");
 
+        await sleep(sleepTime);
         await deleteUrimap(session, options);
+        await sleep(sleepTime);
     });
 
     it("should get a syntax error if urimap name is omitted", () => {
@@ -176,7 +184,8 @@ describe("CICS define urimap-client command", () => {
         expect(output.stdout.toString()).toContain(urimapName);
         expect(output.stdout.toString()).toContain("ENABLED");
 
+        await sleep(sleepTime);
         await deleteUrimap(session, options);
+        await sleep(sleepTime);
     });
-
 });

--- a/__tests__/__system__/cli/define/urimap-client/cli.define.urimap.client.system.test.ts
+++ b/__tests__/__system__/cli/define/urimap-client/cli.define.urimap.client.system.test.ts
@@ -28,12 +28,6 @@ let protocol: string;
 let rejectUnauthorized: boolean;
 let session: Session;
 
-function sleep(ms: number) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-const sleepTime = 2000;
-
 describe("CICS define urimap-client command", () => {
 
     beforeAll(async () => {
@@ -71,31 +65,6 @@ describe("CICS define urimap-client command", () => {
         expect(output.stderr.toString()).toEqual("");
         expect(output.status).toEqual(0);
         expect(output.stdout.toString()).toMatchSnapshot();
-    });
-
-    it("should be able to successfully define a client urimap with basic options", async () => {
-        const urimapNameSuffixLength = 4;
-        const urimapName = "DFN" + generateRandomAlphaNumericString(urimapNameSuffixLength);
-        const options: IURIMapParms = { name: urimapName, csdGroup, regionName };
-        let output = runCliScript(__dirname + "/__scripts__/define_urimap_client.sh", TEST_ENVIRONMENT,
-            [urimapName, csdGroup, "urimap/test/invalid.html", "www.example.com", regionName]);
-        let stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain("success");
-
-        output = runCliScript(__dirname + "/__scripts__/get_resource_urimap.sh", TEST_ENVIRONMENT,
-            [regionName,
-                csdGroup]);
-        stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain(urimapName);
-        expect(output.stdout.toString()).toContain("ENABLED");
-
-        await sleep(sleepTime);
-        await deleteUrimap(session, options);
-        await sleep(sleepTime);
     });
 
     it("should get a syntax error if urimap name is omitted", () => {
@@ -142,50 +111,5 @@ describe("CICS define urimap-client command", () => {
         expect(stderr).toContain("Syntax");
         expect(stderr).toContain("region-name");
         expect(output.status).toEqual(1);
-    });
-
-    it("should be able to successfully define a client urimap using profile options", async () => {
-        const urimapNameSuffixLength = 4;
-        const urimapName = "DFN" + generateRandomAlphaNumericString(urimapNameSuffixLength);
-        const urimapHost = "www.example.com";
-        const urimapScheme = "http";
-        const urimapPath = "urimap/test/invalid.html";
-        const options: IURIMapParms = { name: urimapName, csdGroup, regionName };
-        let output = runCliScript(__dirname + "/__scripts__/define_urimap_client_fully_qualified.sh", TEST_ENVIRONMENT,
-            [urimapName,
-                csdGroup,
-                urimapPath,
-                urimapHost,
-                urimapScheme,
-                regionName,
-                host,
-                port,
-                user,
-                password,
-                protocol,
-                rejectUnauthorized]);
-        let stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain("success");
-
-        output = runCliScript(__dirname + "/__scripts__/get_resource_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
-            [regionName,
-                csdGroup,
-                host,
-                port,
-                user,
-                password,
-                protocol,
-                rejectUnauthorized]);
-        stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain(urimapName);
-        expect(output.stdout.toString()).toContain("ENABLED");
-
-        await sleep(sleepTime);
-        await deleteUrimap(session, options);
-        await sleep(sleepTime);
     });
 });

--- a/__tests__/__system__/cli/define/urimap-pipeline/__scripts__/define_urimap_pipeline.sh
+++ b/__tests__/__system__/cli/define/urimap-pipeline/__scripts__/define_urimap_pipeline.sh
@@ -8,4 +8,4 @@ urimap_host=$4
 pipeline_name=$5
 region_name=$6
 
-zowe cics define urimap-pipeline "$urimap_name" "$csd_group" --urimap-path "$urimap_path" --urimap-host "$urimap_host" --pipeline-name "$pipeline_name" --region-name "$region_name"
+zowe cics define urimap-pipeline "$urimap_name" "$csd_group" --urimap-path "$urimap_path" --urimap-host "$urimap_host" --pipeline-name "$pipeline_name" --region-name "$region_name" --enable false

--- a/__tests__/__system__/cli/define/urimap-pipeline/__scripts__/define_urimap_pipeline_all_options.sh
+++ b/__tests__/__system__/cli/define/urimap-pipeline/__scripts__/define_urimap_pipeline_all_options.sh
@@ -11,4 +11,4 @@ description=$7
 transaction_name=$8
 webservice_name=$9
 
-zowe cics define urimap-pipeline "$urimap_name" "$csd_group" --urimap-path "$urimap_path" --urimap-host "$urimap_host" --pipeline-name "$pipeline_name" --region-name "$region_name" --description "$description" --transaction-name "$transaction_name" --webservice-name "$webservice_name"
+zowe cics define urimap-pipeline "$urimap_name" "$csd_group" --urimap-path "$urimap_path" --urimap-host "$urimap_host" --pipeline-name "$pipeline_name" --region-name "$region_name" --description "$description" --transaction-name "$transaction_name" --webservice-name "$webservice_name"  --enable false

--- a/__tests__/__system__/cli/define/urimap-pipeline/__scripts__/define_urimap_pipeline_fully_qualified.sh
+++ b/__tests__/__system__/cli/define/urimap-pipeline/__scripts__/define_urimap_pipeline_fully_qualified.sh
@@ -14,4 +14,4 @@ USER=${10}
 PASSWORD=${11}
 PROTOCOL=${12}
 REJECT=${13}
-zowe cics define urimap-pipeline "$urimap_name" "$csd_group" --urimap-path "$urimap_path" --urimap-host "$urimap_host" --urimap-scheme "$urimap_scheme" --pipeline-name "$pipeline_name" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"
+zowe cics define urimap-pipeline "$urimap_name" "$csd_group" --urimap-path "$urimap_path" --urimap-host "$urimap_host" --urimap-scheme "$urimap_scheme" --pipeline-name "$pipeline_name" --region-name "$region_name"  --enable false --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"

--- a/__tests__/__system__/cli/define/urimap-pipeline/__snapshots__/cli.define.urimap.pipeline.system.test.ts.snap
+++ b/__tests__/__system__/cli/define/urimap-pipeline/__snapshots__/cli.define.urimap.pipeline.system.test.ts.snap
@@ -79,6 +79,12 @@ exports[`CICS define urimap-pipeline command should be able to display the help 
 
       The name of the CICSPlex to which to define the new URIMAP.
 
+   --enable  (boolean)
+
+      Whether or not the URIMAP is to be enabled on install by default.
+
+      Default value: true
+
  CICS CONNECTION OPTIONS
  -----------------------
 

--- a/__tests__/__system__/cli/define/urimap-pipeline/cli.define.urimap.pipeline.system.test.ts
+++ b/__tests__/__system__/cli/define/urimap-pipeline/cli.define.urimap.pipeline.system.test.ts
@@ -27,6 +27,12 @@ let protocol: string;
 let rejectUnauthorized: boolean;
 let session: Session;
 
+function sleep(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const sleepTime = 2000;
+
 describe("CICS define urimap-pipeline command", () => {
 
     beforeAll(async () => {
@@ -67,7 +73,7 @@ describe("CICS define urimap-pipeline command", () => {
     });
 
     it("should be able to successfully define a pipeline urimap with basic options", async () => {
-        const urimapNameSuffixLength = 4;
+        const urimapNameSuffixLength = 5;
         const urimapName = "DFN" + generateRandomAlphaNumericString(urimapNameSuffixLength);
         const options: IURIMapParms = { name: urimapName, csdGroup, regionName };
         let output = runCliScript(__dirname + "/__scripts__/define_urimap_pipeline.sh", TEST_ENVIRONMENT,
@@ -86,7 +92,9 @@ describe("CICS define urimap-pipeline command", () => {
         expect(output.stdout.toString()).toContain(urimapName);
         expect(output.stdout.toString()).toContain("ENABLED");
 
+        await sleep(sleepTime);
         await deleteUrimap(session, options);
+        await sleep(sleepTime);
     });
 
     it("should be able to successfully define a pipeline urimap with all options", async () => {
@@ -116,7 +124,9 @@ describe("CICS define urimap-pipeline command", () => {
         expect(output.stdout.toString()).toContain(transactionName);
         expect(output.stdout.toString()).toContain(webserviceName);
 
+        await sleep(sleepTime);
         await deleteUrimap(session, options);
+        await sleep(sleepTime);
     });
 
     it("should get a syntax error if urimap name is omitted", () => {
@@ -216,7 +226,9 @@ describe("CICS define urimap-pipeline command", () => {
         expect(output.stdout.toString()).toContain(urimapName);
         expect(output.stdout.toString()).toContain("ENABLED");
 
+        await sleep(sleepTime);
         await deleteUrimap(session, options);
+        await sleep(sleepTime);
     });
 
 });

--- a/__tests__/__system__/cli/define/urimap-pipeline/cli.define.urimap.pipeline.system.test.ts
+++ b/__tests__/__system__/cli/define/urimap-pipeline/cli.define.urimap.pipeline.system.test.ts
@@ -27,12 +27,6 @@ let protocol: string;
 let rejectUnauthorized: boolean;
 let session: Session;
 
-function sleep(ms: number) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-const sleepTime = 2000;
-
 describe("CICS define urimap-pipeline command", () => {
 
     beforeAll(async () => {
@@ -70,63 +64,6 @@ describe("CICS define urimap-pipeline command", () => {
         expect(output.stderr.toString()).toEqual("");
         expect(output.status).toEqual(0);
         expect(output.stdout.toString()).toMatchSnapshot();
-    });
-
-    it("should be able to successfully define a pipeline urimap with basic options", async () => {
-        const urimapNameSuffixLength = 5;
-        const urimapName = "DFN" + generateRandomAlphaNumericString(urimapNameSuffixLength);
-        const options: IURIMapParms = { name: urimapName, csdGroup, regionName };
-        let output = runCliScript(__dirname + "/__scripts__/define_urimap_pipeline.sh", TEST_ENVIRONMENT,
-            [urimapName, csdGroup, "urimap/test/invalid.html", "www.example.com", "FAKEPIPE", regionName]);
-        let stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain("success");
-
-        output = runCliScript(__dirname + "/__scripts__/get_resource_urimap.sh", TEST_ENVIRONMENT,
-            [regionName,
-                csdGroup]);
-        stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain(urimapName);
-        expect(output.stdout.toString()).toContain("ENABLED");
-
-        await sleep(sleepTime);
-        await deleteUrimap(session, options);
-        await sleep(sleepTime);
-    });
-
-    it("should be able to successfully define a pipeline urimap with all options", async () => {
-        const urimapNameSuffixLength = 4;
-        const urimapName = "DFN" + generateRandomAlphaNumericString(urimapNameSuffixLength);
-        const description = "hi i am urimap";
-        const transactionName = "tTxn";
-        const webserviceName = "testWebService";
-        const options: IURIMapParms = { name: urimapName, csdGroup, regionName };
-        let output = runCliScript(__dirname + "/__scripts__/define_urimap_pipeline_all_options.sh", TEST_ENVIRONMENT,
-            [urimapName, csdGroup, "urimap/test/invalid.html", "www.example.com", "FAKEPIPE", regionName,
-            description, transactionName, webserviceName]);
-        let stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain("success");
-
-        output = runCliScript(__dirname + "/__scripts__/get_resource_urimap.sh", TEST_ENVIRONMENT,
-            [regionName,
-                csdGroup]);
-        stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain(urimapName);
-        expect(output.stdout.toString()).toContain("ENABLED");
-        expect(output.stdout.toString()).toContain(description);
-        expect(output.stdout.toString()).toContain(transactionName);
-        expect(output.stdout.toString()).toContain(webserviceName);
-
-        await sleep(sleepTime);
-        await deleteUrimap(session, options);
-        await sleep(sleepTime);
     });
 
     it("should get a syntax error if urimap name is omitted", () => {
@@ -183,52 +120,4 @@ describe("CICS define urimap-pipeline command", () => {
         expect(stderr).toContain("region-name");
         expect(output.status).toEqual(1);
     });
-
-    it("should be able to successfully define a pipeline urimap using profile options", async () => {
-        const urimapNameSuffixLength = 4;
-        const urimapName = "DFN" + generateRandomAlphaNumericString(urimapNameSuffixLength);
-        const urimapHost = "www.example.com";
-        const urimapScheme = "http";
-        const urimapPath = "urimap/test/invalid.html";
-        const pipelineName = "FAKEPIPE";
-        const options: IURIMapParms = { name: urimapName, csdGroup, regionName };
-        let output = runCliScript(__dirname + "/__scripts__/define_urimap_pipeline_fully_qualified.sh", TEST_ENVIRONMENT,
-            [urimapName,
-                csdGroup,
-                urimapPath,
-                urimapHost,
-                urimapScheme,
-                pipelineName,
-                regionName,
-                host,
-                port,
-                user,
-                password,
-                protocol,
-                rejectUnauthorized]);
-        let stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain("success");
-
-        output = runCliScript(__dirname + "/__scripts__/get_resource_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
-            [regionName,
-                csdGroup,
-                host,
-                port,
-                user,
-                password,
-                protocol,
-                rejectUnauthorized]);
-        stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain(urimapName);
-        expect(output.stdout.toString()).toContain("ENABLED");
-
-        await sleep(sleepTime);
-        await deleteUrimap(session, options);
-        await sleep(sleepTime);
-    });
-
 });

--- a/__tests__/__system__/cli/define/urimap-server/__scripts__/define_urimap_server.sh
+++ b/__tests__/__system__/cli/define/urimap-server/__scripts__/define_urimap_server.sh
@@ -8,4 +8,4 @@ urimap_host=$4
 program_name=$5
 region_name=$6
 
-zowe cics define urimap-server "$urimap_name" "$csd_group" --urimap-path "$urimap_path" --urimap-host "$urimap_host" --program-name "$program_name" --region-name "$region_name"
+zowe cics define urimap-server "$urimap_name" "$csd_group" --urimap-path "$urimap_path" --urimap-host "$urimap_host" --program-name "$program_name" --region-name "$region_name" --enable false

--- a/__tests__/__system__/cli/define/urimap-server/__scripts__/define_urimap_server_fully_qualified.sh
+++ b/__tests__/__system__/cli/define/urimap-server/__scripts__/define_urimap_server_fully_qualified.sh
@@ -14,4 +14,4 @@ USER=${10}
 PASSWORD=${11}
 PROTOCOL=${12}
 REJECT=${13}
-zowe cics define urimap-server "$urimap_name" "$csd_group" --urimap-path "$urimap_path" --urimap-host "$urimap_host" --urimap-scheme "$urimap_scheme" --program-name "$program_name" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"
+zowe cics define urimap-server "$urimap_name" "$csd_group" --urimap-path "$urimap_path" --urimap-host "$urimap_host" --urimap-scheme "$urimap_scheme" --program-name "$program_name" --region-name "$region_name"  --enable false --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"

--- a/__tests__/__system__/cli/define/urimap-server/__snapshots__/cli.define.urimap.server.system.test.ts.snap
+++ b/__tests__/__system__/cli/define/urimap-server/__snapshots__/cli.define.urimap.server.system.test.ts.snap
@@ -67,6 +67,12 @@ exports[`CICS define urimap-server command should be able to display the help 1`
 
       The name of the CICSPlex to which to define the new URIMAP.
 
+   --enable  (boolean)
+
+      Whether or not the URIMAP is to be enabled on install by default.
+
+      Default value: true
+
  CICS CONNECTION OPTIONS
  -----------------------
 

--- a/__tests__/__system__/cli/define/urimap-server/cli.define.urimap.server.system.test.ts
+++ b/__tests__/__system__/cli/define/urimap-server/cli.define.urimap.server.system.test.ts
@@ -27,6 +27,12 @@ let protocol: string;
 let rejectUnauthorized: boolean;
 let session: Session;
 
+function sleep(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const sleepTime = 2000;
+
 describe("CICS define urimap-server command", () => {
 
     beforeAll(async () => {
@@ -86,7 +92,9 @@ describe("CICS define urimap-server command", () => {
         expect(output.stdout.toString()).toContain(urimapName);
         expect(output.stdout.toString()).toContain("ENABLED");
 
+        await sleep(sleepTime);
         await deleteUrimap(session, options);
+        await sleep(sleepTime);
     });
 
     it("should get a syntax error if urimap name is omitted", () => {
@@ -186,7 +194,9 @@ describe("CICS define urimap-server command", () => {
         expect(output.stdout.toString()).toContain(urimapName);
         expect(output.stdout.toString()).toContain("ENABLED");
 
+        await sleep(sleepTime);
         await deleteUrimap(session, options);
+        await sleep(sleepTime);
     });
 
 });

--- a/__tests__/__system__/cli/define/urimap-server/cli.define.urimap.server.system.test.ts
+++ b/__tests__/__system__/cli/define/urimap-server/cli.define.urimap.server.system.test.ts
@@ -27,12 +27,6 @@ let protocol: string;
 let rejectUnauthorized: boolean;
 let session: Session;
 
-function sleep(ms: number) {
-    return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-const sleepTime = 2000;
-
 describe("CICS define urimap-server command", () => {
 
     beforeAll(async () => {
@@ -70,31 +64,6 @@ describe("CICS define urimap-server command", () => {
         expect(output.stderr.toString()).toEqual("");
         expect(output.status).toEqual(0);
         expect(output.stdout.toString()).toMatchSnapshot();
-    });
-
-    it("should be able to successfully define a server urimap with basic options", async () => {
-        const urimapNameSuffixLength = 4;
-        const urimapName = "DFN" + generateRandomAlphaNumericString(urimapNameSuffixLength);
-        const options: IURIMapParms = { name: urimapName, csdGroup, regionName };
-        let output = runCliScript(__dirname + "/__scripts__/define_urimap_server.sh", TEST_ENVIRONMENT,
-            [urimapName, csdGroup, "urimap/test/invalid.html", "www.example.com", "IEFBR14", regionName]);
-        let stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain("success");
-
-        output = runCliScript(__dirname + "/__scripts__/get_resource_urimap.sh", TEST_ENVIRONMENT,
-            [regionName,
-                csdGroup]);
-        stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain(urimapName);
-        expect(output.stdout.toString()).toContain("ENABLED");
-
-        await sleep(sleepTime);
-        await deleteUrimap(session, options);
-        await sleep(sleepTime);
     });
 
     it("should get a syntax error if urimap name is omitted", () => {
@@ -150,53 +119,6 @@ describe("CICS define urimap-server command", () => {
         expect(stderr).toContain("Syntax");
         expect(stderr).toContain("region-name");
         expect(output.status).toEqual(1);
-    });
-
-    it("should be able to successfully define a server urimap using profile options", async () => {
-        const urimapNameSuffixLength = 4;
-        const urimapName = "DFN" + generateRandomAlphaNumericString(urimapNameSuffixLength);
-        const urimapHost = "www.example.com";
-        const urimapScheme = "http";
-        const urimapPath = "urimap/test/invalid.html";
-        const programName = "IEFBR14";
-        const options: IURIMapParms = { name: urimapName, csdGroup, regionName };
-        let output = runCliScript(__dirname + "/__scripts__/define_urimap_server_fully_qualified.sh", TEST_ENVIRONMENT,
-            [urimapName,
-                csdGroup,
-                urimapPath,
-                urimapHost,
-                urimapScheme,
-                programName,
-                regionName,
-                host,
-                port,
-                user,
-                password,
-                protocol,
-                rejectUnauthorized]);
-        let stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain("success");
-
-        output = runCliScript(__dirname + "/__scripts__/get_resource_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
-            [regionName,
-                csdGroup,
-                host,
-                port,
-                user,
-                password,
-                protocol,
-                rejectUnauthorized]);
-        stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain(urimapName);
-        expect(output.stdout.toString()).toContain("ENABLED");
-
-        await sleep(sleepTime);
-        await deleteUrimap(session, options);
-        await sleep(sleepTime);
     });
 
 });

--- a/__tests__/__system__/cli/disable/urimap/__scripts__/disable_urimap.sh
+++ b/__tests__/__system__/cli/disable/urimap/__scripts__/disable_urimap.sh
@@ -2,6 +2,5 @@
 set -e
 
 urimap_name=$1
-csd_group=$2
-region_name=$3
-zowe cics disable urimap "$urimap_name" "$csd_group" --region-name "$region_name"
+region_name=$2
+zowe cics disable urimap "$urimap_name" --region-name "$region_name"

--- a/__tests__/__system__/cli/disable/urimap/__scripts__/disable_urimap_fully_qualified.sh
+++ b/__tests__/__system__/cli/disable/urimap/__scripts__/disable_urimap_fully_qualified.sh
@@ -2,12 +2,11 @@
 set -e
 
 urimap_name=$1
-csd_group=$2
-region_name=$3
-HOST=$4
-PORT=$5
-USER=$6
-PASSWORD=$7
-PROTOCOL=$8
-REJECT=$9
-zowe cics disable urimap "$urimap_name" "$csd_group" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"
+region_name=$2
+HOST=$3
+PORT=$4
+USER=$5
+PASSWORD=$6
+PROTOCOL=$7
+REJECT=$8
+zowe cics disable urimap "$urimap_name" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"

--- a/__tests__/__system__/cli/disable/urimap/__snapshots__/cli.disable.urimap.system.test.ts.snap
+++ b/__tests__/__system__/cli/disable/urimap/__snapshots__/cli.disable.urimap.system.test.ts.snap
@@ -15,7 +15,7 @@ exports[`CICS disable urimap command should be able to display the help 1`] = `
  USAGE
  -----
 
-   zowe cics disable urimap <urimapName> <csdGroup> [options]
+   zowe cics disable urimap <urimapName> [options]
 
  POSITIONAL ARGUMENTS
  --------------------
@@ -24,11 +24,6 @@ exports[`CICS disable urimap command should be able to display the help 1`] = `
 
       The name of the urimap to disable. The maximum length of the urimap name is
       eight characters.
-
-   csdGroup		 (string)
-
-      The CICS system definition (CSD) Group for the new program that you want to
-      disable. The maximum length of the group name is eight characters.
 
  OPTIONS
  -------

--- a/__tests__/__system__/cli/disable/urimap/cli.disable.urimap.system.test.ts
+++ b/__tests__/__system__/cli/disable/urimap/cli.disable.urimap.system.test.ts
@@ -74,7 +74,7 @@ describe("CICS disable urimap command", () => {
         await sleep(sleepTime);
 
         output = runCliScript(__dirname + "/__scripts__/disable_urimap.sh", TEST_ENVIRONMENT,
-            [urimapName, csdGroup, regionName]);
+            [urimapName, regionName]);
         stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
@@ -105,7 +105,7 @@ describe("CICS disable urimap command", () => {
         await sleep(sleepTime);
 
         output = runCliScript(__dirname + "/__scripts__/disable_urimap.sh", TEST_ENVIRONMENT,
-            [urimapName, csdGroup, regionName]);
+            [urimapName, regionName]);
         stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
@@ -135,7 +135,7 @@ describe("CICS disable urimap command", () => {
         await sleep(sleepTime);
 
         output = runCliScript(__dirname + "/__scripts__/disable_urimap.sh", TEST_ENVIRONMENT,
-            [urimapName, csdGroup, regionName]);
+            [urimapName, regionName]);
         stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
@@ -156,15 +156,6 @@ describe("CICS disable urimap command", () => {
         expect(stderr).toContain("Syntax");
         expect(stderr).toContain("Missing Positional Argument");
         expect(stderr).toContain("urimapName");
-        expect(output.status).toEqual(1);
-    });
-
-    it("should get a syntax error if csdGroup is omitted", () => {
-        const output = runCliScript(__dirname + "/__scripts__/disable_urimap.sh", TEST_ENVIRONMENT, ["FAKEURI", "", "FAKEREG"]);
-        const stderr = output.stderr.toString();
-        expect(stderr).toContain("Syntax");
-        expect(stderr).toContain("Missing Positional Argument");
-        expect(stderr).toContain("csdGroup");
         expect(output.status).toEqual(1);
     });
 
@@ -199,7 +190,6 @@ describe("CICS disable urimap command", () => {
 
         output = runCliScript(__dirname + "/__scripts__/disable_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
             [urimapName,
-                csdGroup,
                 regionName,
                 host,
                 port,
@@ -260,7 +250,6 @@ describe("CICS disable urimap command", () => {
 
         output = runCliScript(__dirname + "/__scripts__/disable_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
             [urimapName,
-                csdGroup,
                 regionName,
                 host,
                 port,
@@ -319,7 +308,6 @@ describe("CICS disable urimap command", () => {
 
         output = runCliScript(__dirname + "/__scripts__/disable_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
         [urimapName,
-            csdGroup,
             regionName,
             host,
             port,

--- a/__tests__/__system__/cli/discard/urimap/__scripts__/discard_urimap.sh
+++ b/__tests__/__system__/cli/discard/urimap/__scripts__/discard_urimap.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+urimap_name=$1
+region_name=$2
+zowe cics discard urimap "$urimap_name" --region-name "$region_name"

--- a/__tests__/__system__/cli/discard/urimap/__scripts__/discard_urimap_fully_qualified.sh
+++ b/__tests__/__system__/cli/discard/urimap/__scripts__/discard_urimap_fully_qualified.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+urimap_name=$1
+region_name=$2
+HOST=$3
+PORT=$4
+USER=$5
+PASSWORD=$6
+PROTOCOL=$7
+REJECT=$8
+zowe cics discard urimap "$urimap_name" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"

--- a/__tests__/__system__/cli/discard/urimap/__scripts__/discard_urimap_help.sh
+++ b/__tests__/__system__/cli/discard/urimap/__scripts__/discard_urimap_help.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+zowe cics discard urimap --help

--- a/__tests__/__system__/cli/discard/urimap/__snapshots__/cli.discard.urimap.system.test.ts.snap
+++ b/__tests__/__system__/cli/discard/urimap/__snapshots__/cli.discard.urimap.system.test.ts.snap
@@ -97,7 +97,7 @@ exports[`CICS discard urimap command should be able to display the help 1`] = `
 
    - Discard a urimap named URIMAPA from the region named MYREGION:
 
-      $ zowe cics discard urimap URIMAPA CSDGROUP --region-name MYREGION
+      $ zowe cics discard urimap URIMAPA --region-name MYREGION
 
 "
 `;

--- a/__tests__/__system__/cli/discard/urimap/__snapshots__/cli.discard.urimap.system.test.ts.snap
+++ b/__tests__/__system__/cli/discard/urimap/__snapshots__/cli.discard.urimap.system.test.ts.snap
@@ -1,0 +1,104 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CICS discard urimap command should be able to display the help 1`] = `
+"
+ COMMAND NAME
+ ------------
+
+   urimap
+
+ DESCRIPTION
+ -----------
+
+   Discard a urimap from CICS.
+
+ USAGE
+ -----
+
+   zowe cics discard urimap <urimapName> [options]
+
+ POSITIONAL ARGUMENTS
+ --------------------
+
+   urimapName		 (string)
+
+      The name of the urimap to discard. The maximum length of the urimap name is
+      eight characters.
+
+ OPTIONS
+ -------
+
+   --region-name  (string)
+
+      The CICS region name from which to discard the urimap
+
+ CICS CONNECTION OPTIONS
+ -----------------------
+
+   --host  | -H (string)
+
+      The CICS server host name.
+
+   --port  | -P (number)
+
+      The CICS server port.
+
+      Default value: 443
+
+   --user  | -u (string)
+
+      Mainframe (CICS) user name, which can be the same as your TSO login.
+
+   --password  | --pw (string)
+
+      Mainframe (CICS) password, which can be the same as your TSO password.
+
+   --reject-unauthorized  | --ru (boolean)
+
+      Reject self-signed certificates.
+
+      Default value: true
+
+   --protocol  | -o (string)
+
+      Specifies CMCI protocol (http or https).
+
+      Default value: http
+      Allowed values: http, https
+
+ PROFILE OPTIONS
+ ---------------
+
+   --cics-profile  | --cics-p (string)
+
+      The name of a (cics) profile to load for this command execution.
+
+ GLOBAL OPTIONS
+ --------------
+
+   --response-format-json  | --rfj (boolean)
+
+      Produce JSON formatted data from a command
+
+   --help  | -h (boolean)
+
+      Display help text
+
+   --help-examples  (boolean)
+
+      Display examples for all the commands in a the group
+
+   --help-web  | --hw (boolean)
+
+      Display HTML help in browser
+
+ EXAMPLES
+ --------
+
+   - Discard a urimap named URIMAPA to the region named MYREGION
+   belonging to the csdgroup MYGRP:
+
+      $ zowe cics discard urimap URIMAPA CSDGROUP --region-name MYREGION
+
+"
+`;

--- a/__tests__/__system__/cli/discard/urimap/__snapshots__/cli.discard.urimap.system.test.ts.snap
+++ b/__tests__/__system__/cli/discard/urimap/__snapshots__/cli.discard.urimap.system.test.ts.snap
@@ -95,8 +95,7 @@ exports[`CICS discard urimap command should be able to display the help 1`] = `
  EXAMPLES
  --------
 
-   - Discard a urimap named URIMAPA to the region named MYREGION
-   belonging to the csdgroup MYGRP:
+   - Discard a urimap named URIMAPA from the region named MYREGION:
 
       $ zowe cics discard urimap URIMAPA CSDGROUP --region-name MYREGION
 

--- a/__tests__/__system__/cli/discard/urimap/__snapshots__/cli.discard.urimap.system.test.ts.snap
+++ b/__tests__/__system__/cli/discard/urimap/__snapshots__/cli.discard.urimap.system.test.ts.snap
@@ -95,7 +95,8 @@ exports[`CICS discard urimap command should be able to display the help 1`] = `
  EXAMPLES
  --------
 
-   - Discard a urimap named URIMAPA from the region named MYREGION:
+   - Discard a urimap named URIMAPA from the region named
+   MYREGION:
 
       $ zowe cics discard urimap URIMAPA --region-name MYREGION
 

--- a/__tests__/__system__/cli/discard/urimap/cli.discard.urimap.system.test.ts
+++ b/__tests__/__system__/cli/discard/urimap/cli.discard.urimap.system.test.ts
@@ -29,11 +29,11 @@ function sleep(ms: number) {
 
 const sleepTime = 2000;
 
-describe("CICS disable urimap command", () => {
+describe("CICS discard urimap command", () => {
 
     beforeAll(async () => {
         TEST_ENVIRONMENT = await TestEnvironment.setUp({
-            testName: "disable_urimap",
+            testName: "discard_urimap",
             installPlugin: true,
             tempProfileTypes: ["cics"]
         });
@@ -52,13 +52,13 @@ describe("CICS disable urimap command", () => {
     });
 
     it("should be able to display the help", () => {
-        const output = runCliScript(__dirname + "/__scripts__/disable_urimap_help.sh", TEST_ENVIRONMENT, []);
+        const output = runCliScript(__dirname + "/__scripts__/discard_urimap_help.sh", TEST_ENVIRONMENT, []);
         expect(output.stderr.toString()).toEqual("");
         expect(output.status).toEqual(0);
         expect(output.stdout.toString()).toMatchSnapshot();
     });
 
-    it("should be able to disable a urimap of type server with basic options", async () => {
+    it("should be able to discard a urimap of type server with basic options", async () => {
         const urimapNameSuffixLength = 6;
         const urimapName = "X" + generateRandomAlphaNumericString(urimapNameSuffixLength);
         const urimapPath = "fake/path";
@@ -81,23 +81,7 @@ describe("CICS disable urimap command", () => {
         expect(output.stdout.toString()).toContain("success");
         await sleep(sleepTime);
 
-        output = runCliScript(__dirname + "/../../enable/urimap/__scripts__/enable_urimap.sh", TEST_ENVIRONMENT,
-        [urimapName, regionName]);
-        stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain("success");
-        await sleep(sleepTime);
-
-        output = runCliScript(__dirname + "/__scripts__/disable_urimap.sh", TEST_ENVIRONMENT,
-            [urimapName, regionName]);
-        stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain("success");
-        await sleep(sleepTime);
-
-        output = runCliScript(__dirname + "/../../discard/urimap/__scripts__/discard_urimap.sh", TEST_ENVIRONMENT,
+        output = runCliScript(__dirname + "/__scripts__/discard_urimap.sh", TEST_ENVIRONMENT,
         [urimapName, regionName]);
         stderr = output.stderr.toString();
         expect(stderr).toEqual("");
@@ -113,7 +97,7 @@ describe("CICS disable urimap command", () => {
         expect(output.stdout.toString()).toContain("success");
     });
 
-    it("should be able to disable a urimap of type pipeline with basic options", async () => {
+    it("should be able to discard a urimap of type pipeline with basic options", async () => {
         const urimapNameSuffixLength = 6;
         const urimapName = "X" + generateRandomAlphaNumericString(urimapNameSuffixLength);
         const urimapPath = "fake/path";
@@ -136,23 +120,7 @@ describe("CICS disable urimap command", () => {
         expect(output.stdout.toString()).toContain("success");
         await sleep(sleepTime);
 
-        output = runCliScript(__dirname + "/../../enable/urimap/__scripts__/enable_urimap.sh", TEST_ENVIRONMENT,
-        [urimapName, regionName]);
-        stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain("success");
-        await sleep(sleepTime);
-
-        output = runCliScript(__dirname + "/__scripts__/disable_urimap.sh", TEST_ENVIRONMENT,
-            [urimapName, regionName]);
-        stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain("success");
-        await sleep(sleepTime);
-
-        output = runCliScript(__dirname + "/../../discard/urimap/__scripts__/discard_urimap.sh", TEST_ENVIRONMENT,
+        output = runCliScript(__dirname + "/__scripts__/discard_urimap.sh", TEST_ENVIRONMENT,
         [urimapName, regionName]);
         stderr = output.stderr.toString();
         expect(stderr).toEqual("");
@@ -168,7 +136,7 @@ describe("CICS disable urimap command", () => {
         expect(output.stdout.toString()).toContain("success");
     });
 
-    it("should be able to disable a urimap of type client with basic options", async () => {
+    it("should be able to discard a urimap of type client with basic options", async () => {
         const urimapNameSuffixLength = 6;
         const urimapName = "X" + generateRandomAlphaNumericString(urimapNameSuffixLength);
         const urimapPath = "fake/path";
@@ -190,23 +158,7 @@ describe("CICS disable urimap command", () => {
         expect(output.stdout.toString()).toContain("success");
         await sleep(sleepTime);
 
-        output = runCliScript(__dirname + "/../../enable/urimap/__scripts__/enable_urimap.sh", TEST_ENVIRONMENT,
-        [urimapName, regionName]);
-        stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain("success");
-        await sleep(sleepTime);
-
-        output = runCliScript(__dirname + "/__scripts__/disable_urimap.sh", TEST_ENVIRONMENT,
-            [urimapName, regionName]);
-        stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain("success");
-        await sleep(sleepTime);
-
-        output = runCliScript(__dirname + "/../../discard/urimap/__scripts__/discard_urimap.sh", TEST_ENVIRONMENT,
+        output = runCliScript(__dirname + "/__scripts__/discard_urimap.sh", TEST_ENVIRONMENT,
         [urimapName, regionName]);
         stderr = output.stderr.toString();
         expect(stderr).toEqual("");
@@ -223,7 +175,7 @@ describe("CICS disable urimap command", () => {
     });
 
     it("should get a syntax error if urimapName is omitted", () => {
-        const output = runCliScript(__dirname + "/__scripts__/disable_urimap.sh", TEST_ENVIRONMENT, ["", "FAKEGRP", "FAKEREG"]);
+        const output = runCliScript(__dirname + "/__scripts__/discard_urimap.sh", TEST_ENVIRONMENT, ["", "FAKEREG"]);
         const stderr = output.stderr.toString();
         expect(stderr).toContain("Syntax");
         expect(stderr).toContain("Missing Positional Argument");
@@ -231,7 +183,7 @@ describe("CICS disable urimap command", () => {
         expect(output.status).toEqual(1);
     });
 
-    it("should be able to successfully disable a urimap of type server with profile options", async () => {
+    it("should be able to successfully discard a urimap of type server with profile options", async () => {
 
         const urimapNameSuffixLength = 6;
         const urimapName = "X" + generateRandomAlphaNumericString(urimapNameSuffixLength);
@@ -276,37 +228,7 @@ describe("CICS disable urimap command", () => {
         expect(output.stdout.toString()).toContain("success");
         await sleep(sleepTime);
 
-        output = runCliScript(__dirname + "/../../enable/urimap/__scripts__/enable_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
-        [urimapName,
-            regionName,
-            host,
-            port,
-            user,
-            password,
-            protocol,
-            rejectUnauthorized]);
-        stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain("success");
-        await sleep(sleepTime);
-
-        output = runCliScript(__dirname + "/__scripts__/disable_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
-            [urimapName,
-                regionName,
-                host,
-                port,
-                user,
-                password,
-                protocol,
-                rejectUnauthorized]);
-        stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain("success");
-        await sleep(sleepTime);
-
-        output = runCliScript(__dirname + "/../../discard/urimap/__scripts__/discard_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
+        output = runCliScript(__dirname + "/__scripts__/discard_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
         [urimapName,
             regionName,
             host,
@@ -337,7 +259,7 @@ describe("CICS disable urimap command", () => {
         expect(output.stdout.toString()).toContain("success");
     });
 
-    it("should be able to successfully disable a pipeline of type server with profile options", async () => {
+    it("should be able to successfully discard a pipeline of type server with profile options", async () => {
 
         const urimapNameSuffixLength = 6;
         const urimapName = "X" + generateRandomAlphaNumericString(urimapNameSuffixLength);
@@ -382,37 +304,7 @@ describe("CICS disable urimap command", () => {
         expect(output.stdout.toString()).toContain("success");
         await sleep(sleepTime);
 
-        output = runCliScript(__dirname + "/../../enable/urimap/__scripts__/enable_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
-        [urimapName,
-            regionName,
-            host,
-            port,
-            user,
-            password,
-            protocol,
-            rejectUnauthorized]);
-        stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain("success");
-        await sleep(sleepTime);
-
-        output = runCliScript(__dirname + "/__scripts__/disable_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
-            [urimapName,
-                regionName,
-                host,
-                port,
-                user,
-                password,
-                protocol,
-                rejectUnauthorized]);
-        stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain("success");
-        await sleep(sleepTime);
-
-        output = runCliScript(__dirname + "/../../discard/urimap/__scripts__/discard_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
+        output = runCliScript(__dirname + "/__scripts__/discard_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
         [urimapName,
             regionName,
             host,
@@ -443,7 +335,7 @@ describe("CICS disable urimap command", () => {
         expect(output.stdout.toString()).toContain("success");
     });
 
-    it("should be able to successfully disable a urimap of type client with profile options", async () => {
+    it("should be able to successfully discard a urimap of type client with profile options", async () => {
 
         const urimapNameSuffixLength = 6;
         const urimapName = "X" + generateRandomAlphaNumericString(urimapNameSuffixLength);
@@ -473,36 +365,6 @@ describe("CICS disable urimap command", () => {
         output = runCliScript(__dirname + "/../../install/urimap/__scripts__/install_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
         [urimapName,
             csdGroup,
-            regionName,
-            host,
-            port,
-            user,
-            password,
-            protocol,
-            rejectUnauthorized]);
-        stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain("success");
-        await sleep(sleepTime);
-
-        output = runCliScript(__dirname + "/../../enable/urimap/__scripts__/enable_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
-        [urimapName,
-            regionName,
-            host,
-            port,
-            user,
-            password,
-            protocol,
-            rejectUnauthorized]);
-        stderr = output.stderr.toString();
-        expect(stderr).toEqual("");
-        expect(output.status).toEqual(0);
-        expect(output.stdout.toString()).toContain("success");
-        await sleep(sleepTime);
-
-        output = runCliScript(__dirname + "/__scripts__/disable_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
-        [urimapName,
             regionName,
             host,
             port,

--- a/__tests__/__system__/cli/enable/urimap/__scripts__/enable_urimap.sh
+++ b/__tests__/__system__/cli/enable/urimap/__scripts__/enable_urimap.sh
@@ -2,6 +2,5 @@
 set -e
 
 urimap_name=$1
-csd_group=$2
-region_name=$3
-zowe cics enable urimap "$urimap_name" "$csd_group" --region-name "$region_name"
+region_name=$2
+zowe cics enable urimap "$urimap_name" --region-name "$region_name"

--- a/__tests__/__system__/cli/enable/urimap/__scripts__/enable_urimap_fully_qualified.sh
+++ b/__tests__/__system__/cli/enable/urimap/__scripts__/enable_urimap_fully_qualified.sh
@@ -2,12 +2,11 @@
 set -e
 
 urimap_name=$1
-csd_group=$2
-region_name=$3
-HOST=$4
-PORT=$5
-USER=$6
-PASSWORD=$7
-PROTOCOL=$8
-REJECT=$9
-zowe cics enable urimap "$urimap_name" "$csd_group" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"
+region_name=$2
+HOST=$3
+PORT=$4
+USER=$5
+PASSWORD=$6
+PROTOCOL=$7
+REJECT=$8
+zowe cics enable urimap "$urimap_name" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"

--- a/__tests__/__system__/cli/enable/urimap/__snapshots__/cli.enable.urimap.system.test.ts.snap
+++ b/__tests__/__system__/cli/enable/urimap/__snapshots__/cli.enable.urimap.system.test.ts.snap
@@ -15,7 +15,7 @@ exports[`CICS enable urimap command should be able to display the help 1`] = `
  USAGE
  -----
 
-   zowe cics enable urimap <urimapName> <csdGroup> [options]
+   zowe cics enable urimap <urimapName> [options]
 
  POSITIONAL ARGUMENTS
  --------------------
@@ -24,11 +24,6 @@ exports[`CICS enable urimap command should be able to display the help 1`] = `
 
       The name of the urimap to enable. The maximum length of the urimap name is eight
       characters.
-
-   csdGroup		 (string)
-
-      The CICS system definition (CSD) Group for the new program that you want to
-      disable. The maximum length of the group name is eight characters.
 
  OPTIONS
  -------

--- a/__tests__/__system__/cli/enable/urimap/cli.enable.urimap.system.test.ts
+++ b/__tests__/__system__/cli/enable/urimap/cli.enable.urimap.system.test.ts
@@ -74,7 +74,7 @@ describe("CICS enable urimap command", () => {
         await sleep(sleepTime);
 
         output = runCliScript(__dirname + "/../../disable/urimap/__scripts__/disable_urimap.sh", TEST_ENVIRONMENT,
-            [urimapName, csdGroup, regionName]);
+            [urimapName, regionName]);
         stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
@@ -82,7 +82,7 @@ describe("CICS enable urimap command", () => {
         await sleep(sleepTime);
 
         output = runCliScript(__dirname + "/__scripts__/enable_urimap.sh", TEST_ENVIRONMENT,
-            [urimapName, csdGroup, regionName]);
+            [urimapName, regionName]);
         stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
@@ -113,7 +113,7 @@ describe("CICS enable urimap command", () => {
         await sleep(sleepTime);
 
         output = runCliScript(__dirname + "/../../disable/urimap/__scripts__/disable_urimap.sh", TEST_ENVIRONMENT,
-            [urimapName, csdGroup, regionName]);
+            [urimapName, regionName]);
         stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
@@ -121,7 +121,7 @@ describe("CICS enable urimap command", () => {
         await sleep(sleepTime);
 
         output = runCliScript(__dirname + "/__scripts__/enable_urimap.sh", TEST_ENVIRONMENT,
-            [urimapName, csdGroup, regionName]);
+            [urimapName, regionName]);
         stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
@@ -151,7 +151,7 @@ describe("CICS enable urimap command", () => {
         await sleep(sleepTime);
 
         output = runCliScript(__dirname + "/../../disable/urimap/__scripts__/disable_urimap.sh", TEST_ENVIRONMENT,
-            [urimapName, csdGroup, regionName]);
+            [urimapName, regionName]);
         stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
@@ -159,7 +159,7 @@ describe("CICS enable urimap command", () => {
         await sleep(sleepTime);
 
         output = runCliScript(__dirname + "/__scripts__/enable_urimap.sh", TEST_ENVIRONMENT,
-        [urimapName, csdGroup, regionName]);
+        [urimapName, regionName]);
         stderr = output.stderr.toString();
         expect(stderr).toEqual("");
         expect(output.status).toEqual(0);
@@ -180,15 +180,6 @@ describe("CICS enable urimap command", () => {
         expect(stderr).toContain("Syntax");
         expect(stderr).toContain("Missing Positional Argument");
         expect(stderr).toContain("urimapName");
-        expect(output.status).toEqual(1);
-    });
-
-    it("should get a syntax error if csdGroup is omitted", () => {
-        const output = runCliScript(__dirname + "/__scripts__/enable_urimap.sh", TEST_ENVIRONMENT, ["FAKEURI", "", "FAKEREG"]);
-        const stderr = output.stderr.toString();
-        expect(stderr).toContain("Syntax");
-        expect(stderr).toContain("Missing Positional Argument");
-        expect(stderr).toContain("csdGroup");
         expect(output.status).toEqual(1);
     });
 
@@ -223,7 +214,6 @@ describe("CICS enable urimap command", () => {
 
         output = runCliScript(__dirname + "/../../disable/urimap/__scripts__/disable_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
             [urimapName,
-                csdGroup,
                 regionName,
                 host,
                 port,
@@ -239,7 +229,6 @@ describe("CICS enable urimap command", () => {
 
         output = runCliScript(__dirname + "/__scripts__/enable_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
             [urimapName,
-                csdGroup,
                 regionName,
                 host,
                 port,
@@ -300,7 +289,6 @@ describe("CICS enable urimap command", () => {
 
         output = runCliScript(__dirname + "/../../disable/urimap/__scripts__/disable_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
             [urimapName,
-                csdGroup,
                 regionName,
                 host,
                 port,
@@ -316,7 +304,6 @@ describe("CICS enable urimap command", () => {
 
         output = runCliScript(__dirname + "/__scripts__/enable_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
         [urimapName,
-            csdGroup,
             regionName,
             host,
             port,
@@ -375,7 +362,6 @@ describe("CICS enable urimap command", () => {
 
         output = runCliScript(__dirname + "/../../disable/urimap/__scripts__/disable_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
         [urimapName,
-            csdGroup,
             regionName,
             host,
             port,
@@ -391,7 +377,6 @@ describe("CICS enable urimap command", () => {
 
         output = runCliScript(__dirname + "/__scripts__/enable_urimap_fully_qualified.sh", TEST_ENVIRONMENT,
         [urimapName,
-            csdGroup,
             regionName,
             host,
             port,

--- a/__tests__/__system__/cli/install/urimap/__scripts__/install_urimap.sh
+++ b/__tests__/__system__/cli/install/urimap/__scripts__/install_urimap.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+urimap_name=$1
+csd_group=$2
+region_name=$3
+zowe cics install urimap "$urimap_name" "$csd_group" --region-name "$region_name"

--- a/__tests__/__system__/cli/install/urimap/__scripts__/install_urimap_fully_qualified.sh
+++ b/__tests__/__system__/cli/install/urimap/__scripts__/install_urimap_fully_qualified.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+urimap_name=$1
+csd_group=$2
+region_name=$3
+HOST=$4
+PORT=$5
+USER=$6
+PASSWORD=$7
+PROTOCOL=$8
+REJECT=$9
+zowe cics install urimap "$urimap_name" "$csd_group" --region-name "$region_name" --host $HOST --port $PORT --user $USER --password $PASSWORD --protocol "$PROTOCOL" --reject-unauthorized "$REJECT"

--- a/__tests__/__system__/cli/install/urimap/__scripts__/install_urimap_help.sh
+++ b/__tests__/__system__/cli/install/urimap/__scripts__/install_urimap_help.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+zowe cics install urimap --help

--- a/__tests__/__system__/cli/install/urimap/__snapshots__/cli.install.urimap.system.test.ts.snap
+++ b/__tests__/__system__/cli/install/urimap/__snapshots__/cli.install.urimap.system.test.ts.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CICS install urimap command should be able to display the help 1`] = `
+"
+ COMMAND NAME
+ ------------
+
+   urimap
+
+ DESCRIPTION
+ -----------
+
+   Install a urimap to CICS.
+
+ USAGE
+ -----
+
+   zowe cics install urimap <urimapName> <csdGroup> [options]
+
+ POSITIONAL ARGUMENTS
+ --------------------
+
+   urimapName		 (string)
+
+      The name of the urimap to install. The maximum length of the urimap name is
+      eight characters.
+
+   csdGroup		 (string)
+
+      The CICS system definition (CSD) Group for the urimap that you want to install.
+      The maximum length of the group name is eight characters.
+
+ OPTIONS
+ -------
+
+   --region-name  (string)
+
+      The CICS region name to which to install the urimap
+
+ CICS CONNECTION OPTIONS
+ -----------------------
+
+   --host  | -H (string)
+
+      The CICS server host name.
+
+   --port  | -P (number)
+
+      The CICS server port.
+
+      Default value: 443
+
+   --user  | -u (string)
+
+      Mainframe (CICS) user name, which can be the same as your TSO login.
+
+   --password  | --pw (string)
+
+      Mainframe (CICS) password, which can be the same as your TSO password.
+
+   --reject-unauthorized  | --ru (boolean)
+
+      Reject self-signed certificates.
+
+      Default value: true
+
+   --protocol  | -o (string)
+
+      Specifies CMCI protocol (http or https).
+
+      Default value: http
+      Allowed values: http, https
+
+ PROFILE OPTIONS
+ ---------------
+
+   --cics-profile  | --cics-p (string)
+
+      The name of a (cics) profile to load for this command execution.
+
+ GLOBAL OPTIONS
+ --------------
+
+   --response-format-json  | --rfj (boolean)
+
+      Produce JSON formatted data from a command
+
+   --help  | -h (boolean)
+
+      Display help text
+
+   --help-examples  (boolean)
+
+      Display examples for all the commands in a the group
+
+   --help-web  | --hw (boolean)
+
+      Display HTML help in browser
+
+ EXAMPLES
+ --------
+
+   - Install a urimap named URIMAPA to the region named MYREGION
+   belonging to the csdgroup MYGRP:
+
+      $ zowe cics install urimap URIMAPA CSDGROUP --region-name MYREGION
+
+"
+`;

--- a/__tests__/__system__/cli/install/urimap/cli.install.urimap.system.test.ts
+++ b/__tests__/__system__/cli/install/urimap/cli.install.urimap.system.test.ts
@@ -29,11 +29,11 @@ function sleep(ms: number) {
 
 const sleepTime = 2000;
 
-describe("CICS enable urimap command", () => {
+describe("CICS install urimap command", () => {
 
     beforeAll(async () => {
         TEST_ENVIRONMENT = await TestEnvironment.setUp({
-            testName: "enable_urimap",
+            testName: "install_urimap",
             installPlugin: true,
             tempProfileTypes: ["cics"]
         });
@@ -52,14 +52,14 @@ describe("CICS enable urimap command", () => {
     });
 
     it("should be able to display the help", () => {
-        const output = runCliScript(__dirname + "/__scripts__/enable_urimap_help.sh", TEST_ENVIRONMENT, []);
+        const output = runCliScript(__dirname + "/__scripts__/install_urimap_help.sh", TEST_ENVIRONMENT, []);
         expect(output.stderr.toString()).toEqual("");
         expect(output.status).toEqual(0);
         expect(output.stdout.toString()).toMatchSnapshot();
     });
 
     it("should get a syntax error if urimapName is omitted", () => {
-        const output = runCliScript(__dirname + "/__scripts__/enable_urimap.sh", TEST_ENVIRONMENT, ["", "FAKEGRP", "FAKEREG"]);
+        const output = runCliScript(__dirname + "/__scripts__/install_urimap.sh", TEST_ENVIRONMENT, ["", "FAKEGRP", "FAKEREG"]);
         const stderr = output.stderr.toString();
         expect(stderr).toContain("Syntax");
         expect(stderr).toContain("Missing Positional Argument");

--- a/__tests__/api/methods/define/Define.urimap-client.unit.test.ts
+++ b/__tests__/api/methods/define/Define.urimap-client.unit.test.ts
@@ -308,7 +308,8 @@ describe("CMCI - Define client URIMap", () => {
                             path,
                             host,
                             scheme,
-                            usage: "client"
+                            usage: "client",
+                            status: "ENABLED"
                         }
                     }
                 }

--- a/__tests__/api/methods/define/Define.urimap-pipeline.unit.test.ts
+++ b/__tests__/api/methods/define/Define.urimap-pipeline.unit.test.ts
@@ -366,7 +366,8 @@ describe("CMCI - Define pipeline URIMap", () => {
                             host,
                             scheme,
                             pipeline,
-                            usage: "pipeline"
+                            usage: "pipeline",
+                            status: "ENABLED"
                         }
                     }
                 }

--- a/__tests__/api/methods/define/Define.urimap-server.unit.test.ts
+++ b/__tests__/api/methods/define/Define.urimap-server.unit.test.ts
@@ -363,7 +363,8 @@ describe("CMCI - Define server URIMap", () => {
                             host,
                             scheme,
                             program,
-                            usage: "server"
+                            usage: "server",
+                            status: "ENABLED"
                         }
                     }
                 }

--- a/__tests__/api/methods/disable/Disable.urimap.unit.test.ts
+++ b/__tests__/api/methods/disable/Disable.urimap.unit.test.ts
@@ -22,13 +22,11 @@ describe("CMCI - Disable urimap", () => {
 
     const urimap = "urimap";
     const region = "region";
-    const csdgroup =  "mygroup";
     const content = "ThisIsATest";
 
     const disableParms: IURIMapParms = {
         regionName: region,
-        name: urimap,
-        csdGroup: csdgroup
+        name: urimap
     };
 
     const dummySession = new Session({
@@ -49,7 +47,6 @@ describe("CMCI - Disable urimap", () => {
             error = undefined;
             disableParms.regionName = region;
             disableParms.name = urimap;
-            disableParms.csdGroup = csdgroup;
         });
 
         it("should throw an error if no region name is specified", async () => {
@@ -75,18 +72,6 @@ describe("CMCI - Disable urimap", () => {
             expect(error).toBeDefined();
             expect(error.message).toContain("CICS URIMap name is required");
         });
-
-        it("should throw an error if no CSD group is specified", async () => {
-            disableParms.csdGroup = undefined;
-            try {
-                response = await disableUrimap(dummySession, disableParms);
-            } catch (err) {
-                error = err;
-            }
-            expect(response).toBeUndefined();
-            expect(error).toBeDefined();
-            expect(error.message).toContain("CICS CSD group name is required");
-        });
     });
 
     describe("success scenarios", () => {
@@ -99,19 +84,18 @@ describe("CMCI - Disable urimap", () => {
             disableSpy.mockImplementation(() => content);
             disableParms.regionName = region;
             disableParms.name = urimap;
-            disableParms.csdGroup = csdgroup;
         });
 
         it("should be able to disable a urimap", async () => {
             endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-            CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + region +
-            `?CRITERIA=(NAME=${disableParms.name})&PARAMETER=CSDGROUP(${disableParms.csdGroup})`;
+            CicsCmciConstants.CICS_URIMAP + "/" + region +
+            `?CRITERIA=(NAME=${disableParms.name})`;
             requestBody = {
                 request: {
                     update: {
                         attributes: {
                             $: {
-                                STATUS: "DISABLED"
+                                ENABLESTATUS: "DISABLED"
                             }
                         }
                     }

--- a/__tests__/api/methods/discard/Discard.urimap.unit.test.ts
+++ b/__tests__/api/methods/discard/Discard.urimap.unit.test.ts
@@ -1,0 +1,98 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { Session } from "@zowe/imperative";
+import {
+    CicsCmciConstants,
+    CicsCmciRestClient,
+    discardUrimap,
+    IProgramParms,
+    IURIMapParms,
+} from "../../../../src";
+
+describe("CMCI - Discard urimap", () => {
+
+    const urimap = "urimap";
+    const region = "region";
+    const content = "ThisIsATest";
+
+    const discardParms: IURIMapParms = {
+        regionName: region,
+        name: urimap
+    };
+
+    const dummySession = new Session({
+        user: "fake",
+        password: "fake",
+        hostname: "fake",
+        port: 1490
+    });
+
+    let error: any;
+    let response: any;
+    let endPoint: any;
+
+    describe("validation", () => {
+        beforeEach(() => {
+            response = undefined;
+            error = undefined;
+            discardParms.regionName = region;
+            discardParms.name = urimap;
+        });
+
+        it("should throw an error if no region name is specified", async () => {
+            discardParms.regionName = undefined;
+            try {
+                response = await discardUrimap(dummySession, discardParms);
+            } catch (err) {
+                error = err;
+            }
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS region name is required");
+        });
+
+        it("should throw an error if no urimap name is specified", async () => {
+            discardParms.name = undefined;
+            try {
+                response = await discardUrimap(dummySession, discardParms);
+            } catch (err) {
+                error = err;
+            }
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS URIMap name is required");
+        });
+    });
+
+    describe("success scenarios", () => {
+        const discardSpy = jest.spyOn(CicsCmciRestClient, "deleteExpectParsedXml").mockReturnValue(content);
+
+        beforeEach(() => {
+            response = undefined;
+            error = undefined;
+            discardSpy.mockClear();
+            discardSpy.mockImplementation(() => content);
+            discardParms.regionName = region;
+            discardParms.name = urimap;
+        });
+
+        it("should be able to discard a urimap", async () => {
+            endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+            CicsCmciConstants.CICS_URIMAP + "/" + region +
+            `?CRITERIA=(NAME='${discardParms.name}')`;
+
+            response = await discardUrimap(dummySession, discardParms);
+            expect(response).toContain(content);
+            expect(discardSpy).toHaveBeenCalledWith(dummySession, endPoint, []);
+        });
+    });
+});

--- a/__tests__/api/methods/enable/Enable.urimap.unit.test.ts
+++ b/__tests__/api/methods/enable/Enable.urimap.unit.test.ts
@@ -22,13 +22,11 @@ describe("CMCI - enable urimap", () => {
 
     const urimap = "urimap";
     const region = "region";
-    const csdgroup = "group";
     const content = "ThisIsATest";
 
     const enableParms: IURIMapParms = {
         regionName: region,
-        name: urimap,
-        csdGroup: csdgroup
+        name: urimap
     };
 
     const dummySession = new Session({
@@ -49,7 +47,6 @@ describe("CMCI - enable urimap", () => {
             error = undefined;
             enableParms.regionName = region;
             enableParms.name = urimap;
-            enableParms.csdGroup = csdgroup;
         });
 
         it("should throw an error if no region name is specified", async () => {
@@ -75,18 +72,6 @@ describe("CMCI - enable urimap", () => {
             expect(error).toBeDefined();
             expect(error.message).toContain("CICS URIMap name is required");
         });
-
-        it("should throw an error if no csd group is specified", async () => {
-            enableParms.csdGroup = undefined;
-            try {
-                response = await enableUrimap(dummySession, enableParms);
-            } catch (err) {
-                error = err;
-            }
-            expect(response).toBeUndefined();
-            expect(error).toBeDefined();
-            expect(error.message).toContain("CICS CSD group name is required");
-        });
     });
 
     describe("success scenarios", () => {
@@ -99,19 +84,18 @@ describe("CMCI - enable urimap", () => {
             enableSpy.mockImplementation(() => content);
             enableParms.regionName = region;
             enableParms.name = urimap;
-            enableParms.csdGroup = csdgroup;
         });
 
         it("should be able to enable a urimap", async () => {
             endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-            CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + region +
-            `?CRITERIA=(NAME=${enableParms.name})&PARAMETER=CSDGROUP(${enableParms.csdGroup})`;
+            CicsCmciConstants.CICS_URIMAP + "/" + region +
+            `?CRITERIA=(NAME=${enableParms.name})`;
             requestBody = {
                 request: {
                     update: {
                         attributes: {
                             $: {
-                                STATUS: "ENABLED"
+                                ENABLESTATUS: "ENABLED"
                             }
                         }
                     }

--- a/__tests__/api/methods/install/Install.urimap.unit.test.ts
+++ b/__tests__/api/methods/install/Install.urimap.unit.test.ts
@@ -1,0 +1,124 @@
+/*
+* This program and the accompanying materials are made available under the terms of the *
+* Eclipse Public License v2.0 which accompanies this distribution, and is available at *
+* https://www.eclipse.org/legal/epl-v20.html                                      *
+*                                                                                 *
+* SPDX-License-Identifier: EPL-2.0                                                *
+*                                                                                 *
+* Copyright Contributors to the Zowe Project.                                     *
+*                                                                                 *
+*/
+
+import { Session } from "@zowe/imperative";
+import {
+    CicsCmciConstants,
+    CicsCmciRestClient,
+    installUrimap,
+    IProgramParms,
+    IURIMapParms,
+} from "../../../../src";
+
+describe("CMCI - Install urimap", () => {
+
+    const urimap = "urimap";
+    const region = "region";
+    const group = "group";
+    const content = "ThisIsATest";
+
+    const installParms: IURIMapParms = {
+        regionName: region,
+        name: urimap,
+        csdGroup: group
+    };
+
+    const dummySession = new Session({
+        user: "fake",
+        password: "fake",
+        hostname: "fake",
+        port: 1490
+    });
+
+    let error: any;
+    let response: any;
+    let endPoint: any;
+    let requestBody: any;
+
+    describe("validation", () => {
+        beforeEach(() => {
+            response = undefined;
+            error = undefined;
+            installParms.regionName = region;
+            installParms.name = urimap;
+            installParms.csdGroup = group;
+        });
+
+        it("should throw an error if no region name is specified", async () => {
+            installParms.regionName = undefined;
+            try {
+                response = await installUrimap(dummySession, installParms);
+            } catch (err) {
+                error = err;
+            }
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS region name is required");
+        });
+
+        it("should throw an error if no urimap name is specified", async () => {
+            installParms.name = undefined;
+            try {
+                response = await installUrimap(dummySession, installParms);
+            } catch (err) {
+                error = err;
+            }
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS URIMap name is required");
+        });
+
+        it("should throw an error if no csdGroup name is specified", async () => {
+            installParms.csdGroup = undefined;
+            try {
+                response = await installUrimap(dummySession, installParms);
+            } catch (err) {
+                error = err;
+            }
+            expect(response).toBeUndefined();
+            expect(error).toBeDefined();
+            expect(error.message).toContain("CICS CSD group name is required");
+        });
+    });
+
+    describe("success scenarios", () => {
+        const installSpy = jest.spyOn(CicsCmciRestClient, "putExpectParsedXml").mockReturnValue(content);
+
+        beforeEach(() => {
+            response = undefined;
+            error = undefined;
+            installSpy.mockClear();
+            installSpy.mockImplementation(() => content);
+            installParms.regionName = region;
+            installParms.name = urimap;
+            installParms.csdGroup = group;
+        });
+
+        it("should be able to install a urimap", async () => {
+            endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+            CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + region +
+            `?CRITERIA=(NAME=${installParms.name})&PARAMETER=CSDGROUP(${installParms.csdGroup})`;
+            requestBody = {
+                request: {
+                    action: {
+                        $: {
+                            name: "CSDINSTALL",
+                        }
+                    }
+                }
+            };
+
+            response = await installUrimap(dummySession, installParms);
+            expect(response).toContain(content);
+            expect(installSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+        });
+    });
+});

--- a/__tests__/cli/define/urimap-client/UrimapClient.handler.unit.test.ts
+++ b/__tests__/cli/define/urimap-client/UrimapClient.handler.unit.test.ts
@@ -140,7 +140,8 @@ describe("DefineUrimapClientHandler", () => {
                 scheme: urimapScheme,
                 regionName,
                 cicsPlex,
-                enable
+                enable,
+                description: undefined
             }
         );
     });

--- a/__tests__/cli/define/urimap-client/__snapshots__/UrimapClient.definition.unit.test.ts.snap
+++ b/__tests__/cli/define/urimap-client/__snapshots__/UrimapClient.definition.unit.test.ts.snap
@@ -66,6 +66,12 @@ Object {
       "name": "cics-plex",
       "type": "string",
     },
+    Object {
+      "defaultValue": true,
+      "description": "Whether or not the URIMAP is to be enabled on install by default. ",
+      "name": "enable",
+      "type": "boolean",
+    },
   ],
   "positionals": Array [
     Object {

--- a/__tests__/cli/define/urimap-pipeline/UrimapPipeline.handler.unit.test.ts
+++ b/__tests__/cli/define/urimap-pipeline/UrimapPipeline.handler.unit.test.ts
@@ -84,6 +84,7 @@ describe("DefineUrimapPipelineHandler", () => {
     const description = "description";
     const transactionName = "testTransaction";
     const webserviceName = "testWebservice";
+    const enable = false;
 
     const defaultReturn: ICMCIApiResponse = {
         response: {
@@ -113,6 +114,7 @@ describe("DefineUrimapPipelineHandler", () => {
             urimapScheme,
             regionName,
             cicsPlex,
+            enable,
             host,
             port,
             user,
@@ -143,7 +145,8 @@ describe("DefineUrimapPipelineHandler", () => {
                 pipelineName,
                 scheme: urimapScheme,
                 regionName,
-                cicsPlex
+                cicsPlex,
+                enable
             }
         );
     });

--- a/__tests__/cli/define/urimap-pipeline/UrimapPipeline.handler.unit.test.ts
+++ b/__tests__/cli/define/urimap-pipeline/UrimapPipeline.handler.unit.test.ts
@@ -146,7 +146,10 @@ describe("DefineUrimapPipelineHandler", () => {
                 scheme: urimapScheme,
                 regionName,
                 cicsPlex,
-                enable
+                enable,
+                description: undefined,
+                transactionName: undefined,
+                webserviceName: undefined
             }
         );
     });

--- a/__tests__/cli/define/urimap-pipeline/__snapshots__/UrimapPipeline.definition.unit.test.ts.snap
+++ b/__tests__/cli/define/urimap-pipeline/__snapshots__/UrimapPipeline.definition.unit.test.ts.snap
@@ -91,6 +91,12 @@ Object {
       "name": "cics-plex",
       "type": "string",
     },
+    Object {
+      "defaultValue": true,
+      "description": "Whether or not the URIMAP is to be enabled on install by default. ",
+      "name": "enable",
+      "type": "boolean",
+    },
   ],
   "positionals": Array [
     Object {

--- a/__tests__/cli/define/urimap-server/UrimapServer.handler.unit.test.ts
+++ b/__tests__/cli/define/urimap-server/UrimapServer.handler.unit.test.ts
@@ -143,7 +143,8 @@ describe("DefineUrimapServerHandler", () => {
                 scheme: urimapScheme,
                 regionName,
                 cicsPlex,
-                enable
+                enable,
+                description: undefined
             }
         );
     });

--- a/__tests__/cli/define/urimap-server/UrimapServer.handler.unit.test.ts
+++ b/__tests__/cli/define/urimap-server/UrimapServer.handler.unit.test.ts
@@ -81,6 +81,7 @@ describe("DefineUrimapServerHandler", () => {
     const urimapPath = "testPath";
     const urimapScheme = "http";
     const cicsPlex = "testPlex";
+    const enable = false;
 
     const defaultReturn: ICMCIApiResponse = {
         response: {
@@ -110,6 +111,7 @@ describe("DefineUrimapServerHandler", () => {
             urimapScheme,
             regionName,
             cicsPlex,
+            enable,
             host,
             port,
             user,
@@ -140,7 +142,8 @@ describe("DefineUrimapServerHandler", () => {
                 programName,
                 scheme: urimapScheme,
                 regionName,
-                cicsPlex
+                cicsPlex,
+                enable
             }
         );
     });

--- a/__tests__/cli/define/urimap-server/__snapshots__/UrimapServer.definition.unit.test.ts.snap
+++ b/__tests__/cli/define/urimap-server/__snapshots__/UrimapServer.definition.unit.test.ts.snap
@@ -75,6 +75,12 @@ Object {
       "name": "cics-plex",
       "type": "string",
     },
+    Object {
+      "defaultValue": true,
+      "description": "Whether or not the URIMAP is to be enabled on install by default. ",
+      "name": "enable",
+      "type": "boolean",
+    },
   ],
   "positionals": Array [
     Object {

--- a/__tests__/cli/disable/urimap/Urimap.handler.unit.test.ts
+++ b/__tests__/cli/disable/urimap/Urimap.handler.unit.test.ts
@@ -77,7 +77,6 @@ const DEFAULT_PARAMETERS: IHandlerParameters = {
 describe("DisableUrimapHandler", () => {
     const urimapName = "testUrimap";
     const regionName = "testRegion";
-    const csdGroup = "testGroup";
 
     const defaultReturn: ICMCIApiResponse = {
         response: {
@@ -101,7 +100,6 @@ describe("DisableUrimapHandler", () => {
             ...commandParameters.arguments,
             urimapName,
             regionName,
-            csdGroup,
             host,
             port,
             user,
@@ -126,7 +124,6 @@ describe("DisableUrimapHandler", () => {
             }),
             {
                 name: urimapName,
-                csdGroup,
                 regionName
             }
         );

--- a/__tests__/cli/disable/urimap/__snapshots__/Urimap.definition.unit.test.ts.snap
+++ b/__tests__/cli/disable/urimap/__snapshots__/Urimap.definition.unit.test.ts.snap
@@ -25,12 +25,6 @@ Object {
       "required": true,
       "type": "string",
     },
-    Object {
-      "description": "The CICS system definition (CSD) Group for the new program that you want to disable. The maximum length of the group name is eight characters.",
-      "name": "csdGroup",
-      "required": true,
-      "type": "string",
-    },
   ],
   "profile": Object {
     "optional": Array [

--- a/__tests__/cli/discard/urimap/Urimap.definition.unit.test.ts
+++ b/__tests__/cli/discard/urimap/Urimap.definition.unit.test.ts
@@ -11,14 +11,11 @@
 
 import { ICommandDefinition } from "@zowe/imperative";
 
-describe("cics discard program", () => {
-    const DISCARD_RESOURCES = 3;
-
+describe("cics discard urimap", () => {
     it ("should not have changed", () => {
-        const definition: ICommandDefinition = require("../../../src/cli/discard/Discard.definition");
+        const definition: ICommandDefinition = require("../../../../src/cli/discard/urimap/Urimap.definition").UrimapDefinition;
         expect(definition).toBeDefined();
-        expect(definition.children.length).toBe(DISCARD_RESOURCES);
-        delete definition.children;
+        delete definition.handler;
         expect(definition).toMatchSnapshot();
     });
 });

--- a/__tests__/cli/discard/urimap/Urimap.handler.unit.test.ts
+++ b/__tests__/cli/discard/urimap/Urimap.handler.unit.test.ts
@@ -11,11 +11,11 @@
 
 import { CommandProfiles, IHandlerParameters, IProfile, Session } from "@zowe/imperative";
 import { ICMCIApiResponse } from "../../../../src";
-import { UrimapClientDefinition } from "../../../../src/cli/define/urimap-client/UrimapClient.definition";
-import UrimapClientHandler from "../../../../src/cli/define/urimap-client/UrimapClient.handler";
+import { UrimapDefinition } from "../../../../src/cli/discard/urimap/Urimap.definition";
+import UrimapHandler from "../../../../src/cli/discard/urimap/Urimap.handler";
 
-jest.mock("../../../../src/api/methods/define");
-const Define = require("../../../../src/api/methods/define");
+jest.mock("../../../../src/api/methods/discard");
+const Discard = require("../../../../src/api/methods/discard");
 
 const host = "somewhere.com";
 const port = "43443";
@@ -32,7 +32,9 @@ PROFILE_MAP.set(
         host,
         port,
         user,
-        password
+        password,
+        protocol,
+        rejectUnauthorized
     }]
 );
 const PROFILES: CommandProfiles = new CommandProfiles(PROFILE_MAP);
@@ -67,20 +69,14 @@ const DEFAULT_PARAMETERS: IHandlerParameters = {
             })
         }
     },
-    definition: UrimapClientDefinition,
-    fullDefinition: UrimapClientDefinition,
+    definition: UrimapDefinition,
+    fullDefinition: UrimapDefinition,
     profiles: PROFILES
 };
 
-describe("DefineUrimapClientHandler", () => {
-    const regionName = "testRegion";
-    const csdGroup = "testGroup";
+describe("DiscardUrimapHandler", () => {
     const urimapName = "testUrimap";
-    const urimapHost = "testHost";
-    const urimapPath = "testPath";
-    const urimapScheme = "http";
-    const cicsPlex = "testPlex";
-    const enable = false;
+    const regionName = "testRegion";
 
     const defaultReturn: ICMCIApiResponse = {
         response: {
@@ -89,33 +85,27 @@ describe("DefineUrimapClientHandler", () => {
         }
     };
 
-    const functionSpy = jest.spyOn(Define, "defineUrimapClient");
+    const functionSpy = jest.spyOn(Discard, "discardUrimap");
 
     beforeEach(() => {
         functionSpy.mockClear();
         functionSpy.mockImplementation(async () => defaultReturn);
     });
 
-    it("should call the defineUrimapClient api", async () => {
-        const handler = new UrimapClientHandler();
+    it("should call the discardUrimap api", async () => {
+        const handler = new UrimapHandler();
 
         const commandParameters = {...DEFAULT_PARAMETERS};
         commandParameters.arguments = {
             ...commandParameters.arguments,
             urimapName,
-            csdGroup,
-            urimapPath,
-            urimapHost,
-            urimapScheme,
             regionName,
-            cicsPlex,
-            enable,
             host,
             port,
             user,
             password,
-            rejectUnauthorized,
-            protocol
+            protocol,
+            rejectUnauthorized
         };
 
         await handler.process(commandParameters);
@@ -134,13 +124,7 @@ describe("DefineUrimapClientHandler", () => {
             }),
             {
                 name: urimapName,
-                csdGroup,
-                path: urimapPath,
-                host: urimapHost,
-                scheme: urimapScheme,
-                regionName,
-                cicsPlex,
-                enable
+                regionName
             }
         );
     });

--- a/__tests__/cli/discard/urimap/__snapshots__/Urimap.definition.unit.test.ts.snap
+++ b/__tests__/cli/discard/urimap/__snapshots__/Urimap.definition.unit.test.ts.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cics discard urimap should not have changed 1`] = `
+Object {
+  "aliases": Array [],
+  "description": "Discard a urimap from CICS.",
+  "examples": Array [
+    Object {
+      "description": "Discard a urimap named URIMAPA to the region named MYREGION belonging to the csdgroup MYGRP",
+      "options": "URIMAPA CSDGROUP --region-name MYREGION",
+    },
+  ],
+  "name": "urimap",
+  "options": Array [
+    Object {
+      "description": "The CICS region name from which to discard the urimap",
+      "name": "region-name",
+      "type": "string",
+    },
+  ],
+  "positionals": Array [
+    Object {
+      "description": "The name of the urimap to discard. The maximum length of the urimap name is eight characters.",
+      "name": "urimapName",
+      "required": true,
+      "type": "string",
+    },
+  ],
+  "profile": Object {
+    "optional": Array [
+      "cics",
+    ],
+  },
+  "type": "command",
+}
+`;

--- a/__tests__/cli/discard/urimap/__snapshots__/Urimap.definition.unit.test.ts.snap
+++ b/__tests__/cli/discard/urimap/__snapshots__/Urimap.definition.unit.test.ts.snap
@@ -6,8 +6,8 @@ Object {
   "description": "Discard a urimap from CICS.",
   "examples": Array [
     Object {
-      "description": "Discard a urimap named URIMAPA to the region named MYREGION belonging to the csdgroup MYGRP",
-      "options": "URIMAPA CSDGROUP --region-name MYREGION",
+      "description": "Discard a urimap named URIMAPA from the region named MYREGION",
+      "options": "URIMAPA --region-name MYREGION",
     },
   ],
   "name": "urimap",

--- a/__tests__/cli/discard/urimap/__snapshots__/Urimap.handler.unit.test.ts.snap
+++ b/__tests__/cli/discard/urimap/__snapshots__/Urimap.handler.unit.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DiscardUrimapHandler should call the discardUrimap api 1`] = `"The urimap '%s' was discarded successfully."`;
+
+exports[`DiscardUrimapHandler should call the discardUrimap api 2`] = `
+Object {
+  "response": Object {
+    "records": "testing",
+    "resultsummary": Object {
+      "api_response1": "1024",
+      "api_response2": "0",
+      "displayed_recordcount": "0",
+      "recordcount": "0",
+    },
+  },
+}
+`;

--- a/__tests__/cli/enable/urimap/Urimap.handler.unit.test.ts
+++ b/__tests__/cli/enable/urimap/Urimap.handler.unit.test.ts
@@ -77,7 +77,6 @@ const DEFAULT_PARAMETERS: IHandlerParameters = {
 describe("enableUrimapHandler", () => {
     const urimapName = "testUrimap";
     const regionName = "testRegion";
-    const csdGroup = "testGroup";
 
     const defaultReturn: ICMCIApiResponse = {
         response: {
@@ -101,7 +100,6 @@ describe("enableUrimapHandler", () => {
             ...commandParameters.arguments,
             urimapName,
             regionName,
-            csdGroup,
             host,
             port,
             user,
@@ -126,7 +124,6 @@ describe("enableUrimapHandler", () => {
             }),
             {
                 name: urimapName,
-                csdGroup,
                 regionName
             }
         );

--- a/__tests__/cli/enable/urimap/__snapshots__/Urimap.definition.unit.test.ts.snap
+++ b/__tests__/cli/enable/urimap/__snapshots__/Urimap.definition.unit.test.ts.snap
@@ -25,12 +25,6 @@ Object {
       "required": true,
       "type": "string",
     },
-    Object {
-      "description": "The CICS system definition (CSD) Group for the new program that you want to disable. The maximum length of the group name is eight characters.",
-      "name": "csdGroup",
-      "required": true,
-      "type": "string",
-    },
   ],
   "profile": Object {
     "optional": Array [

--- a/__tests__/cli/install/Install.definition.unit.test.ts
+++ b/__tests__/cli/install/Install.definition.unit.test.ts
@@ -12,7 +12,7 @@
 import { ICommandDefinition } from "@zowe/imperative";
 
 describe("cics install program", () => {
-    const INSTALL_RESOURCES = 2;
+    const INSTALL_RESOURCES = 3;
 
     it ("should not have changed", () => {
         const definition: ICommandDefinition = require("../../../src/cli/install/Install.definition");

--- a/__tests__/cli/install/urimap/Urimap.definition.unit.test.ts
+++ b/__tests__/cli/install/urimap/Urimap.definition.unit.test.ts
@@ -11,14 +11,11 @@
 
 import { ICommandDefinition } from "@zowe/imperative";
 
-describe("cics discard program", () => {
-    const DISCARD_RESOURCES = 3;
-
+describe("cics install urimap", () => {
     it ("should not have changed", () => {
-        const definition: ICommandDefinition = require("../../../src/cli/discard/Discard.definition");
+        const definition: ICommandDefinition = require("../../../../src/cli/install/urimap/Urimap.definition").UrimapDefinition;
         expect(definition).toBeDefined();
-        expect(definition.children.length).toBe(DISCARD_RESOURCES);
-        delete definition.children;
+        delete definition.handler;
         expect(definition).toMatchSnapshot();
     });
 });

--- a/__tests__/cli/install/urimap/Urimap.handler.unit.test.ts
+++ b/__tests__/cli/install/urimap/Urimap.handler.unit.test.ts
@@ -11,11 +11,11 @@
 
 import { CommandProfiles, IHandlerParameters, IProfile, Session } from "@zowe/imperative";
 import { ICMCIApiResponse } from "../../../../src";
-import { UrimapClientDefinition } from "../../../../src/cli/define/urimap-client/UrimapClient.definition";
-import UrimapClientHandler from "../../../../src/cli/define/urimap-client/UrimapClient.handler";
+import { UrimapDefinition } from "../../../../src/cli/install/urimap/Urimap.definition";
+import UrimapHandler from "../../../../src/cli/install/urimap/Urimap.handler";
 
-jest.mock("../../../../src/api/methods/define");
-const Define = require("../../../../src/api/methods/define");
+jest.mock("../../../../src/api/methods/install");
+const Install = require("../../../../src/api/methods/install");
 
 const host = "somewhere.com";
 const port = "43443";
@@ -32,7 +32,9 @@ PROFILE_MAP.set(
         host,
         port,
         user,
-        password
+        password,
+        protocol,
+        rejectUnauthorized
     }]
 );
 const PROFILES: CommandProfiles = new CommandProfiles(PROFILE_MAP);
@@ -67,20 +69,15 @@ const DEFAULT_PARAMETERS: IHandlerParameters = {
             })
         }
     },
-    definition: UrimapClientDefinition,
-    fullDefinition: UrimapClientDefinition,
+    definition: UrimapDefinition,
+    fullDefinition: UrimapDefinition,
     profiles: PROFILES
 };
 
-describe("DefineUrimapClientHandler", () => {
+describe("InstallUrimapHandler", () => {
+    const urimapName = "testUrimap";
     const regionName = "testRegion";
     const csdGroup = "testGroup";
-    const urimapName = "testUrimap";
-    const urimapHost = "testHost";
-    const urimapPath = "testPath";
-    const urimapScheme = "http";
-    const cicsPlex = "testPlex";
-    const enable = false;
 
     const defaultReturn: ICMCIApiResponse = {
         response: {
@@ -89,33 +86,28 @@ describe("DefineUrimapClientHandler", () => {
         }
     };
 
-    const functionSpy = jest.spyOn(Define, "defineUrimapClient");
+    const functionSpy = jest.spyOn(Install, "installUrimap");
 
     beforeEach(() => {
         functionSpy.mockClear();
         functionSpy.mockImplementation(async () => defaultReturn);
     });
 
-    it("should call the defineUrimapClient api", async () => {
-        const handler = new UrimapClientHandler();
+    it("should call the installUrimap api", async () => {
+        const handler = new UrimapHandler();
 
         const commandParameters = {...DEFAULT_PARAMETERS};
         commandParameters.arguments = {
             ...commandParameters.arguments,
             urimapName,
-            csdGroup,
-            urimapPath,
-            urimapHost,
-            urimapScheme,
             regionName,
-            cicsPlex,
-            enable,
+            csdGroup,
             host,
             port,
             user,
             password,
-            rejectUnauthorized,
-            protocol
+            protocol,
+            rejectUnauthorized
         };
 
         await handler.process(commandParameters);
@@ -135,12 +127,7 @@ describe("DefineUrimapClientHandler", () => {
             {
                 name: urimapName,
                 csdGroup,
-                path: urimapPath,
-                host: urimapHost,
-                scheme: urimapScheme,
-                regionName,
-                cicsPlex,
-                enable
+                regionName
             }
         );
     });

--- a/__tests__/cli/install/urimap/__snapshots__/Urimap.definition.unit.test.ts.snap
+++ b/__tests__/cli/install/urimap/__snapshots__/Urimap.definition.unit.test.ts.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cics install urimap should not have changed 1`] = `
+Object {
+  "aliases": Array [],
+  "description": "Install a urimap to CICS.",
+  "examples": Array [
+    Object {
+      "description": "Install a urimap named URIMAPA to the region named MYREGION belonging to the csdgroup MYGRP",
+      "options": "URIMAPA CSDGROUP --region-name MYREGION",
+    },
+  ],
+  "name": "urimap",
+  "options": Array [
+    Object {
+      "description": "The CICS region name to which to install the urimap",
+      "name": "region-name",
+      "type": "string",
+    },
+  ],
+  "positionals": Array [
+    Object {
+      "description": "The name of the urimap to install. The maximum length of the urimap name is eight characters.",
+      "name": "urimapName",
+      "required": true,
+      "type": "string",
+    },
+    Object {
+      "description": "The CICS system definition (CSD) Group for the urimap that you want to install. The maximum length of the group name is eight characters.",
+      "name": "csdGroup",
+      "required": true,
+      "type": "string",
+    },
+  ],
+  "profile": Object {
+    "optional": Array [
+      "cics",
+    ],
+  },
+  "type": "command",
+}
+`;

--- a/__tests__/cli/install/urimap/__snapshots__/Urimap.handler.unit.test.ts.snap
+++ b/__tests__/cli/install/urimap/__snapshots__/Urimap.handler.unit.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InstallUrimapHandler should call the installUrimap api 1`] = `"The urimap '%s' was installed successfully."`;
+
+exports[`InstallUrimapHandler should call the installUrimap api 2`] = `
+Object {
+  "response": Object {
+    "records": "testing",
+    "resultsummary": Object {
+      "api_response1": "1024",
+      "api_response2": "0",
+      "displayed_recordcount": "0",
+      "recordcount": "0",
+    },
+  },
+}
+`;

--- a/src/api/doc/IURIMapParms.ts
+++ b/src/api/doc/IURIMapParms.ts
@@ -78,4 +78,9 @@ export interface IURIMapParms {
      * CICS Plex of the URIMap
      */
     cicsPlex?: string;
+
+    /**
+     * Enable attribute of the URIMap
+     */
+    enable?: boolean;
 }

--- a/src/api/doc/IURIMapParms.ts
+++ b/src/api/doc/IURIMapParms.ts
@@ -20,7 +20,7 @@ export interface IURIMapParms {
      * CSD group for the URIMap
      * Up to eight characters long
      */
-    csdGroup: string;
+    csdGroup?: string;
 
     /**
      * Path component of URI to which the map applies

--- a/src/api/methods/define/Define.ts
+++ b/src/api/methods/define/Define.ts
@@ -231,6 +231,12 @@ function buildUrimapRequestBody(parms: IURIMapParms, usage: "server" | "client" 
         requestAttrs.webservice = parms.webserviceName;
     }
 
+    if (parms.enable === false) {
+        requestAttrs.status = "DISBLED";
+    } else {
+        requestAttrs.status = "ENABLED";
+    }
+
     return {
         request: {
             create: {

--- a/src/api/methods/define/Define.ts
+++ b/src/api/methods/define/Define.ts
@@ -232,7 +232,7 @@ function buildUrimapRequestBody(parms: IURIMapParms, usage: "server" | "client" 
     }
 
     if (parms.enable === false) {
-        requestAttrs.status = "DISBLED";
+        requestAttrs.status = "DISABLED";
     } else {
         requestAttrs.status = "ENABLED";
     }

--- a/src/api/methods/disable/Disable.ts
+++ b/src/api/methods/disable/Disable.ts
@@ -28,21 +28,20 @@ import { ICMCIApiResponse, IProgramParms, ITransactionParms, IURIMapParms } from
 
 export async function disableUrimap(session: AbstractSession, parms: IURIMapParms): Promise<ICMCIApiResponse> {
     ImperativeExpect.toBeDefinedAndNonBlank(parms.name, "CICS URIMap name", "CICS URIMap name is required");
-    ImperativeExpect.toBeDefinedAndNonBlank(parms.csdGroup, "CICS CSD group", "CICS CSD group name is required");
     ImperativeExpect.toBeDefinedAndNonBlank(parms.regionName, "CICS Region name", "CICS region name is required");
 
     Logger.getAppLogger().debug("Attempting to disable a URIMap with the following parameters:\n%s", JSON.stringify(parms));
 
     const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
     const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex +
-        `${parms.regionName}?CRITERIA=(NAME=${parms.name})&PARAMETER=CSDGROUP(${parms.csdGroup})`;
+        CicsCmciConstants.CICS_URIMAP + "/" + cicsPlex +
+        `${parms.regionName}?CRITERIA=(NAME=${parms.name})`;
     const requestBody: any = {
         request: {
             update: {
                 attributes: {
                     $: {
-                        STATUS: "DISABLED"
+                        ENABLESTATUS: "DISABLED"
                     }
                 }
             }

--- a/src/api/methods/discard/Discard.ts
+++ b/src/api/methods/discard/Discard.ts
@@ -12,7 +12,7 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
-import { ICMCIApiResponse, IProgramParms, ITransactionParms } from "../../doc";
+import { ICMCIApiResponse, IProgramParms, ITransactionParms, IURIMapParms } from "../../doc";
 
 /**
  * Discard a program installed in CICS through CMCI REST API
@@ -57,5 +57,18 @@ export async function discardTransaction(session: AbstractSession, parms: ITrans
     const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
         CicsCmciConstants.CICS_LOCAL_TRANSACTION + "/" + cicsPlex + parms.regionName +
         "?CRITERIA=(TRANID=" + parms.name + ")";
+    return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []);
+}
+
+export async function discardUrimap(session: AbstractSession, parms: IURIMapParms): Promise<ICMCIApiResponse> {
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.name, "CICS URIMap name", "CICS URIMap name is required");
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.regionName, "CICS Region name", "CICS region name is required");
+
+    Logger.getAppLogger().debug("Attempting to discard a URIMap with the following parameters:\n%s", JSON.stringify(parms));
+
+    const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
+    const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+        CicsCmciConstants.CICS_URIMAP + "/" + cicsPlex +
+        `${parms.regionName}?CRITERIA=(NAME='${parms.name}')`;
     return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []);
 }

--- a/src/api/methods/enable/Enable.ts
+++ b/src/api/methods/enable/Enable.ts
@@ -28,21 +28,20 @@ import { ICMCIApiResponse, IProgramParms, ITransactionParms, IURIMapParms } from
 
 export async function enableUrimap(session: AbstractSession, parms: IURIMapParms): Promise<ICMCIApiResponse> {
     ImperativeExpect.toBeDefinedAndNonBlank(parms.name, "CICS URIMap name", "CICS URIMap name is required");
-    ImperativeExpect.toBeDefinedAndNonBlank(parms.csdGroup, "CICS CSD group", "CICS CSD group name is required");
     ImperativeExpect.toBeDefinedAndNonBlank(parms.regionName, "CICS Region name", "CICS region name is required");
 
     Logger.getAppLogger().debug("Attempting to enable a URIMap with the following parameters:\n%s", JSON.stringify(parms));
 
     const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
     const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex +
-        `${parms.regionName}?CRITERIA=(NAME=${parms.name})&PARAMETER=CSDGROUP(${parms.csdGroup})`;
+        CicsCmciConstants.CICS_URIMAP + "/" + cicsPlex +
+        `${parms.regionName}?CRITERIA=(NAME=${parms.name})`;
     const requestBody: any = {
         request: {
             update: {
                 attributes: {
                     $: {
-                        STATUS: "ENABLED"
+                        ENABLESTATUS: "ENABLED"
                     }
                 }
             }

--- a/src/api/methods/install/Install.ts
+++ b/src/api/methods/install/Install.ts
@@ -12,7 +12,7 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
-import { ICMCIApiResponse, IProgramParms } from "../../doc";
+import { ICMCIApiResponse, IProgramParms, IURIMapParms } from "../../doc";
 
 /**
  * Install a program definition to CICS through CMCI REST API
@@ -81,4 +81,39 @@ export async function installTransaction(session: AbstractSession, parms: IProgr
         "?CRITERIA=(NAME=" + parms.name + ")&PARAMETER=CSDGROUP(" + parms.csdGroup + ")";
     return CicsCmciRestClient.putExpectParsedXml(session, cmciResource,
         [], requestBody) as any;
+}
+
+/**
+ * Install a URIMap installed in CICS through CMCI REST API
+ * @param {AbstractSession} session - the session to connect to CMCI with
+ * @param {IURIMapParms} parms - parameters for enabling your URIMap
+ * @returns {Promise<ICMCIApiResponse>} promise that resolves to the response (XML parsed into a javascript object)
+ *                          when the request is complete
+ * @throws {ImperativeError} CICS URIMap name not defined or blank
+ * @throws {ImperativeError} CICS CSD group not defined or blank
+ * @throws {ImperativeError} CICS region name not defined or blank
+ * @throws {ImperativeError} CicsCmciRestClient request fails
+ */
+
+export async function installUrimap(session: AbstractSession, parms: IURIMapParms): Promise<ICMCIApiResponse> {
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.name, "CICS URIMap name", "CICS URIMap name is required");
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.csdGroup, "CICS CSD group", "CICS CSD group name is required");
+    ImperativeExpect.toBeDefinedAndNonBlank(parms.regionName, "CICS Region name", "CICS region name is required");
+
+    Logger.getAppLogger().debug("Attempting to install a URIMap with the following parameters:\n%s", JSON.stringify(parms));
+
+    const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
+    const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
+        CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex +
+        `${parms.regionName}?CRITERIA=(NAME=${parms.name})&PARAMETER=CSDGROUP(${parms.csdGroup})`;
+    const requestBody: any = {
+        request: {
+            action: {
+                $: {
+                    name: "CSDINSTALL",
+                }
+            }
+        }
+    };
+    return CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody);
 }

--- a/src/cli/-strings-/en.ts
+++ b/src/cli/-strings-/en.ts
@@ -274,7 +274,7 @@ export default {
                     SUCCESS: "The urimap '%s' was discarded successfully."
                 },
                 EXAMPLES: {
-                    EX1: "Discard a urimap named URIMAPA to the region named MYREGION belonging to the csdgroup MYGRP"
+                    EX1: "Discard a urimap named URIMAPA from the region named MYREGION"
                 }
             }
         }

--- a/src/cli/-strings-/en.ts
+++ b/src/cli/-strings-/en.ts
@@ -211,9 +211,7 @@ export default {
             URIMAP: {
                 DESCRIPTION: "Disable a urimap from CICS.",
                 POSITIONALS: {
-                    URIMAPNAME: "The name of the urimap to disable. The maximum length of the urimap name is eight characters.",
-                    CSDGROUP: "The CICS system definition (CSD) Group for the new program that you want to disable." +
-                    " The maximum length of the group name is eight characters."
+                    URIMAPNAME: "The name of the urimap to disable. The maximum length of the urimap name is eight characters."
                 },
                 OPTIONS: {
                     REGIONNAME: "The CICS region name in which to disable the urimap"
@@ -262,6 +260,21 @@ export default {
                 EXAMPLES: {
                     EX1: "Discard a transaction named TRN1 from the region named MYREGION"
                 }
+            },
+            URIMAP: {
+                DESCRIPTION: "Discard a urimap from CICS.",
+                POSITIONALS: {
+                    URIMAPNAME: "The name of the urimap to discard. The maximum length of the urimap name is eight characters.",
+                },
+                OPTIONS: {
+                    REGIONNAME: "The CICS region name from which to discard the urimap"
+                },
+                MESSAGES: {
+                    SUCCESS: "The urimap '%s' was discarded successfully."
+                },
+                EXAMPLES: {
+                    EX1: "Discard a urimap named URIMAPA to the region named MYREGION belonging to the csdgroup MYGRP"
+                }
             }
         }
     },
@@ -272,9 +285,7 @@ export default {
             URIMAP: {
                 DESCRIPTION: "Enable a urimap from CICS.",
                 POSITIONALS: {
-                    URIMAPNAME: "The name of the urimap to enable. The maximum length of the urimap name is eight characters.",
-                    CSDGROUP: "The CICS system definition (CSD) Group for the new program that you want to disable." +
-                    " The maximum length of the group name is eight characters."
+                    URIMAPNAME: "The name of the urimap to enable. The maximum length of the urimap name is eight characters."
                 },
                 OPTIONS: {
                     REGIONNAME: "The CICS region name in which to enable the urimap"
@@ -359,6 +370,23 @@ export default {
                 EXAMPLES: {
                     EX1: "Install a transaction named TRN1 to the region named MYREGION " +
                         "in the CSD group MYGRP",
+                }
+            },
+            URIMAP: {
+                DESCRIPTION: "Install a urimap to CICS.",
+                POSITIONALS: {
+                    URIMAPNAME: "The name of the urimap to install. The maximum length of the urimap name is eight characters.",
+                    CSDGROUP: "The CICS system definition (CSD) Group for the urimap that you want to install." +
+                        " The maximum length of the group name is eight characters."
+                },
+                OPTIONS: {
+                    REGIONNAME: "The CICS region name to which to install the urimap"
+                },
+                MESSAGES: {
+                    SUCCESS: "The urimap '%s' was installed successfully."
+                },
+                EXAMPLES: {
+                    EX1: "Install a urimap named URIMAPA to the region named MYREGION belonging to the csdgroup MYGRP"
                 }
             }
         }

--- a/src/cli/-strings-/en.ts
+++ b/src/cli/-strings-/en.ts
@@ -79,7 +79,8 @@ export default {
                     TRANSACTIONNAME: "The name of the TRANSACTION resource definition for the URIMAP. " +
                         "The maximum length of the transaction name is four characters.",
                     WEBSERVICENAME: "The name of the WEBSERVICE resource definition for the URIMAP. " +
-                        "The maximum length of the transaction name is 32 characters."
+                        "The maximum length of the transaction name is 32 characters.",
+                    ENABLE: "Whether or not the URIMAP is to be enabled on install by default. "
                 },
                 MESSAGES: {
                     SUCCESS: "The URIMAP '%s' was defined successfully."

--- a/src/cli/define/urimap-client/UrimapClient.definition.ts
+++ b/src/cli/define/urimap-client/UrimapClient.definition.ts
@@ -71,6 +71,12 @@ export const UrimapClientDefinition: ICommandDefinition = {
             name: "cics-plex",
             description: strings.OPTIONS.CICSPLEX,
             type: "string"
+        },
+        {
+            name: "enable",
+            description: strings.OPTIONS.ENABLE,
+            type: "boolean",
+            defaultValue: true
         }],
     profile: {optional: ["cics"]},
     examples: [{

--- a/src/cli/define/urimap-client/UrimapClient.handler.ts
+++ b/src/cli/define/urimap-client/UrimapClient.handler.ts
@@ -41,6 +41,7 @@ export default class UrimapClientHandler extends CicsBaseHandler {
             host: params.arguments.urimapHost,
             scheme: params.arguments.urimapScheme,
             description: params.arguments.description,
+            enable: params.arguments.enable,
             regionName: params.arguments.regionName || profile.regionName,
             cicsPlex: params.arguments.cicsPlex || profile.cicsPlex
         });

--- a/src/cli/define/urimap-pipeline/UrimapPipeline.definition.ts
+++ b/src/cli/define/urimap-pipeline/UrimapPipeline.definition.ts
@@ -90,6 +90,12 @@ export const UrimapPipelineDefinition: ICommandDefinition = {
             name: "cics-plex",
             description: strings.OPTIONS.CICSPLEX,
             type: "string"
+        },
+        {
+            name: "enable",
+            description: strings.OPTIONS.ENABLE,
+            type: "boolean",
+            defaultValue: true
         }],
     profile: {optional: ["cics"]},
     examples: [{

--- a/src/cli/define/urimap-pipeline/UrimapPipeline.handler.ts
+++ b/src/cli/define/urimap-pipeline/UrimapPipeline.handler.ts
@@ -42,6 +42,7 @@ export default class UrimapPipelineHandler extends CicsBaseHandler {
             pipelineName: params.arguments.pipelineName,
             scheme: params.arguments.urimapScheme,
             description: params.arguments.description,
+            enable: params.arguments.enable,
             transactionName: params.arguments.transactionName,
             webserviceName: params.arguments.webserviceName,
             regionName: params.arguments.regionName || profile.regionName,

--- a/src/cli/define/urimap-server/UrimapServer.definition.ts
+++ b/src/cli/define/urimap-server/UrimapServer.definition.ts
@@ -78,6 +78,12 @@ export const UrimapServerDefinition: ICommandDefinition = {
             name: "cics-plex",
             description: strings.OPTIONS.CICSPLEX,
             type: "string"
+        },
+        {
+            name: "enable",
+            description: strings.OPTIONS.ENABLE,
+            type: "boolean",
+            defaultValue: true
         }],
     profile: {optional: ["cics"]},
     examples: [{

--- a/src/cli/define/urimap-server/UrimapServer.handler.ts
+++ b/src/cli/define/urimap-server/UrimapServer.handler.ts
@@ -42,6 +42,7 @@ export default class UrimapServerHandler extends CicsBaseHandler {
             programName: params.arguments.programName,
             scheme: params.arguments.urimapScheme,
             description: params.arguments.description,
+            enable: params.arguments.enable,
             regionName: params.arguments.regionName || profile.regionName,
             cicsPlex: params.arguments.cicsPlex || profile.cicsPlex
         });

--- a/src/cli/discard/Discard.definition.ts
+++ b/src/cli/discard/Discard.definition.ts
@@ -12,6 +12,7 @@
 import { ICommandDefinition } from "@zowe/imperative";
 import { ProgramDefinition } from "./program/Program.definition";
 import { TransactionDefinition } from "./transaction/Transaction.definition";
+import { UrimapDefinition } from "./urimap/Urimap.definition";
 
 import i18nTypings from "../-strings-/en";
 import { CicsSession } from "../CicsSession";
@@ -28,7 +29,8 @@ const definition: ICommandDefinition = {
     description: strings.DESCRIPTION,
     type: "group",
     children: [ProgramDefinition,
-               TransactionDefinition],
+               TransactionDefinition,
+               UrimapDefinition],
     passOn: [
         {
             property: "options",

--- a/src/cli/discard/urimap/Urimap.definition.ts
+++ b/src/cli/discard/urimap/Urimap.definition.ts
@@ -36,6 +36,6 @@ export const UrimapDefinition: ICommandDefinition = {
     profile: {optional: ["cics"]},
     examples: [{
         description: strings.EXAMPLES.EX1,
-        options: "URIMAPA CSDGROUP --region-name MYREGION"
+        options: "URIMAPA --region-name MYREGION"
     }]
 };

--- a/src/cli/discard/urimap/Urimap.definition.ts
+++ b/src/cli/discard/urimap/Urimap.definition.ts
@@ -14,7 +14,7 @@ import { ICommandDefinition } from "@zowe/imperative";
 import i18nTypings from "../../-strings-/en";
 
 // Does not use the import in anticipation of some internationalization work to be done later.
-const strings = (require("../../-strings-/en").default as typeof i18nTypings).DISABLE.RESOURCES.URIMAP;
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).DISCARD.RESOURCES.URIMAP;
 
 export const UrimapDefinition: ICommandDefinition = {
     name: "urimap",
@@ -36,6 +36,6 @@ export const UrimapDefinition: ICommandDefinition = {
     profile: {optional: ["cics"]},
     examples: [{
         description: strings.EXAMPLES.EX1,
-        options: "URIMAPA --region-name MYREGION"
+        options: "URIMAPA CSDGROUP --region-name MYREGION"
     }]
 };

--- a/src/cli/discard/urimap/Urimap.handler.ts
+++ b/src/cli/discard/urimap/Urimap.handler.ts
@@ -10,16 +10,16 @@
 */
 
 import { AbstractSession, ICommandHandler, IHandlerParameters, IProfile, ITaskWithStatus, TaskStage } from "@zowe/imperative";
-import { ICMCIApiResponse, disableUrimap } from "../../../api";
+import { ICMCIApiResponse, discardUrimap } from "../../../api";
 import { CicsBaseHandler } from "../../CicsBaseHandler";
 
 import i18nTypings from "../../-strings-/en";
 
 // Does not use the import in anticipation of some internationalization work to be done later.
-const strings = (require("../../-strings-/en").default as typeof i18nTypings).DISABLE.RESOURCES.URIMAP;
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).DISCARD.RESOURCES.URIMAP;
 
 /**
- * Command handler for disabling CICS URIMaps via CMCI
+ * Command handler for discarding CICS URIMaps via CMCI
  * @export
  * @class UrimapHandler
  * @implements {ICommandHandler}
@@ -29,15 +29,15 @@ export default class UrimapHandler extends CicsBaseHandler {
     public async processWithSession(params: IHandlerParameters, session: AbstractSession, profile: IProfile): Promise<ICMCIApiResponse> {
 
         const status: ITaskWithStatus = {
-            statusMessage: "Disabling URIMAP from CICS",
+            statusMessage: "Discarding URIMAP from CICS",
             percentComplete: 0,
             stageName: TaskStage.IN_PROGRESS
         };
         params.response.progress.startBar({task: status});
 
-        const response = await disableUrimap(session, {
+        const response = await discardUrimap(session, {
             name: params.arguments.urimapName,
-            regionName: params.arguments.regionName || profile.regionName,
+            regionName: params.arguments.regionName || profile.regionName
         });
 
         params.response.console.log(strings.MESSAGES.SUCCESS, params.arguments.urimapName);

--- a/src/cli/enable/urimap/Urimap.definition.ts
+++ b/src/cli/enable/urimap/Urimap.definition.ts
@@ -27,11 +27,6 @@ export const UrimapDefinition: ICommandDefinition = {
         description: strings.POSITIONALS.URIMAPNAME,
         type: "string",
         required: true
-    }, {
-        name: "csdGroup",
-        description: strings.POSITIONALS.CSDGROUP,
-        type: "string",
-        required: true
     }],
     options: [{
         name: "region-name",

--- a/src/cli/enable/urimap/Urimap.handler.ts
+++ b/src/cli/enable/urimap/Urimap.handler.ts
@@ -37,7 +37,6 @@ export default class UrimapHandler extends CicsBaseHandler {
 
         const response = await enableUrimap(session, {
             name: params.arguments.urimapName,
-            csdGroup: params.arguments.csdGroup,
             regionName: params.arguments.regionName || profile.regionName
         });
 

--- a/src/cli/install/Install.definition.ts
+++ b/src/cli/install/Install.definition.ts
@@ -12,6 +12,7 @@
 import { ICommandDefinition } from "@zowe/imperative";
 import { ProgramDefinition } from "./program/Program.definition";
 import { TransactionDefinition } from "./transaction/Transaction.definition";
+import { UrimapDefinition } from "./urimap/Urimap.definition";
 
 import i18nTypings from "../-strings-/en";
 import { CicsSession } from "../CicsSession";
@@ -28,7 +29,8 @@ const definition: ICommandDefinition = {
     description: strings.DESCRIPTION,
     type: "group",
     children: [ProgramDefinition,
-               TransactionDefinition],
+               TransactionDefinition,
+               UrimapDefinition],
     passOn: [
         {
             property: "options",

--- a/src/cli/install/urimap/Urimap.definition.ts
+++ b/src/cli/install/urimap/Urimap.definition.ts
@@ -14,7 +14,7 @@ import { ICommandDefinition } from "@zowe/imperative";
 import i18nTypings from "../../-strings-/en";
 
 // Does not use the import in anticipation of some internationalization work to be done later.
-const strings = (require("../../-strings-/en").default as typeof i18nTypings).DISABLE.RESOURCES.URIMAP;
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).INSTALL.RESOURCES.URIMAP;
 
 export const UrimapDefinition: ICommandDefinition = {
     name: "urimap",
@@ -27,6 +27,11 @@ export const UrimapDefinition: ICommandDefinition = {
         description: strings.POSITIONALS.URIMAPNAME,
         type: "string",
         required: true
+    }, {
+        name: "csdGroup",
+        description: strings.POSITIONALS.CSDGROUP,
+        type: "string",
+        required: true
     }],
     options: [{
         name: "region-name",
@@ -36,6 +41,6 @@ export const UrimapDefinition: ICommandDefinition = {
     profile: {optional: ["cics"]},
     examples: [{
         description: strings.EXAMPLES.EX1,
-        options: "URIMAPA --region-name MYREGION"
+        options: "URIMAPA CSDGROUP --region-name MYREGION"
     }]
 };

--- a/src/cli/install/urimap/Urimap.handler.ts
+++ b/src/cli/install/urimap/Urimap.handler.ts
@@ -10,16 +10,16 @@
 */
 
 import { AbstractSession, ICommandHandler, IHandlerParameters, IProfile, ITaskWithStatus, TaskStage } from "@zowe/imperative";
-import { ICMCIApiResponse, disableUrimap } from "../../../api";
+import { ICMCIApiResponse, installUrimap } from "../../../api";
 import { CicsBaseHandler } from "../../CicsBaseHandler";
 
 import i18nTypings from "../../-strings-/en";
 
 // Does not use the import in anticipation of some internationalization work to be done later.
-const strings = (require("../../-strings-/en").default as typeof i18nTypings).DISABLE.RESOURCES.URIMAP;
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).INSTALL.RESOURCES.URIMAP;
 
 /**
- * Command handler for disabling CICS URIMaps via CMCI
+ * Command handler for installing CICS URIMaps via CMCI
  * @export
  * @class UrimapHandler
  * @implements {ICommandHandler}
@@ -29,15 +29,16 @@ export default class UrimapHandler extends CicsBaseHandler {
     public async processWithSession(params: IHandlerParameters, session: AbstractSession, profile: IProfile): Promise<ICMCIApiResponse> {
 
         const status: ITaskWithStatus = {
-            statusMessage: "Disabling URIMAP from CICS",
+            statusMessage: "Installing URIMAP from CICS",
             percentComplete: 0,
             stageName: TaskStage.IN_PROGRESS
         };
         params.response.progress.startBar({task: status});
 
-        const response = await disableUrimap(session, {
+        const response = await installUrimap(session, {
             name: params.arguments.urimapName,
-            regionName: params.arguments.regionName || profile.regionName,
+            csdGroup: params.arguments.csdGroup,
+            regionName: params.arguments.regionName || profile.regionName
         });
 
         params.response.console.log(strings.MESSAGES.SUCCESS, params.arguments.urimapName);


### PR DESCRIPTION
1. Add the install and discard urimap commands
2. Add the install and discard urimap system and unit tests
3. Add an option to define urimap to allow URIMAPs to be installed as disabled
4. Fix the existing enable and disable urimap commands to function properly
5. Update existing unit and system tests to reflect the proper order of the tests
6. Update test snapshots
7. Remove duplicate system tests

This PR fixes #48, fixes #51