### PR TITLE
Fix example strings.

### DIFF
--- a/__tests__/cli/add-to-list/csdGroup/__snapshots__/CSDGroup.definition.unit.test.ts.snap
+++ b/__tests__/cli/add-to-list/csdGroup/__snapshots__/CSDGroup.definition.unit.test.ts.snap
@@ -8,7 +8,7 @@ Object {
   "description": "Add a CSD Group to a CICS CSD List.",
   "examples": Array [
     Object {
-      "description": "Add the CSD Group CSDGRP to the CSD List CSDLST in the region named MYREG",
+      "description": "Add the CSD Group MYGRP to the CSD List MYLIST in the region named MYREG",
       "options": "MYGRP MYLIST --region-name MYREG",
     },
   ],

--- a/__tests__/cli/remove-from-list/csdGroup/__snapshots__/CSDGroup.definition.unit.test.ts.snap
+++ b/__tests__/cli/remove-from-list/csdGroup/__snapshots__/CSDGroup.definition.unit.test.ts.snap
@@ -8,7 +8,7 @@ Object {
   "description": "Remove a CSD Group from a CICS CSD List.",
   "examples": Array [
     Object {
-      "description": "Remove the CSD Group CSDGRP from the CSD List CSDLST in the region named MYREG",
+      "description": "Remove the CSD Group MYGRP from the CSD List MYLIST in the region named MYREG",
       "options": "MYGRP MYLIST --region-name MYREG",
     },
   ],

--- a/src/cli/-strings-/en.ts
+++ b/src/cli/-strings-/en.ts
@@ -30,7 +30,7 @@ export default {
                     SUCCESS: "The CSD Group '%s' was successfully added to '%s'."
                 },
                 EXAMPLES: {
-                    EX1: "Add the CSD Group CSDGRP to the CSD List CSDLST in the region named MYREG"
+                    EX1: "Add the CSD Group MYGRP to the CSD List MYLIST in the region named MYREG"
                 }
             }
         }
@@ -455,7 +455,7 @@ export default {
                     SUCCESS: "The CSD Group '%s' was successfully removed from '%s'."
                 },
                 EXAMPLES: {
-                    EX1: "Remove the CSD Group CSDGRP from the CSD List CSDLST in the region named MYREG"
+                    EX1: "Remove the CSD Group MYGRP from the CSD List MYLIST in the region named MYREG"
                 }
             }
         }


### PR DESCRIPTION
Fixes the example description strings in en.ts to match the examples provided in the code.

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>