### PR TITLE
Fix bad handler

### DIFF
--- a/__tests__/__system__/cli/add-to-list/csdGroup/__snapshots__/cli.add-to-list.csdGroup.system.test.ts.snap
+++ b/__tests__/__system__/cli/add-to-list/csdGroup/__snapshots__/cli.add-to-list.csdGroup.system.test.ts.snap
@@ -104,7 +104,7 @@ exports[`CICS add-to-list csdGroup command should be able to display the help 1`
  EXAMPLES
  --------
 
-   - Add the CSD Group CSDGRP to the CSD List CSDLST in the
+   - Add the CSD Group MYGRP to the CSD List MYLIST in the
    region named MYREG:
 
       $ zowe cics add-to-list csdGroup MYGRP MYLIST --region-name MYREG

--- a/__tests__/__system__/cli/remove-from-list/csdGroup/__snapshots__/cli.remove-from-list.csdGroup.system.test.ts.snap
+++ b/__tests__/__system__/cli/remove-from-list/csdGroup/__snapshots__/cli.remove-from-list.csdGroup.system.test.ts.snap
@@ -104,7 +104,7 @@ exports[`CICS remove-from-list csdGroup command should be able to display the he
  EXAMPLES
  --------
 
-   - Remove the CSD Group CSDGRP from the CSD List CSDLST in the
+   - Remove the CSD Group MYGRP from the CSD List MYLIST in the
    region named MYREG:
 
       $ zowe cics remove-from-list csdGroup MYGRP MYLIST --region-name MYREG

--- a/src/cli/add-to-list/csdGroup/CSDGroup.definition.ts
+++ b/src/cli/add-to-list/csdGroup/CSDGroup.definition.ts
@@ -20,7 +20,7 @@ export const CSDGroupDefinition: ICommandDefinition = {
     name: "csdGroup",
     aliases: ["csdg"],
     description: strings.DESCRIPTION,
-    handler: __dirname + "/csdGroup.handler",
+    handler: __dirname + "/CSDGroup.handler",
     type: "command",
     positionals: [{
         name: "name",


### PR DESCRIPTION
Fix a problem with one of the CSDGroup handlers not using proper capitalization, and update the system test snapshots to use the updated example string that was merged.