### PR TITLE
bugfix/feature: system tests respect protocol, use HTTPS if none defined

### DIFF
--- a/__tests__/__resources__/properties/example_properties.yaml
+++ b/__tests__/__resources__/properties/example_properties.yaml
@@ -23,5 +23,5 @@ cmci:
   port: my-cics-port
   csdGroup: my-csd-group
   regionName: my-region-name
-  protocol: http
+  protocol: https
   rejectUnauthorized: false

--- a/__tests__/__system__/api/methods/add-to-list/AddToList.csdGroup.system.test.ts
+++ b/__tests__/__system__/api/methods/add-to-list/AddToList.csdGroup.system.test.ts
@@ -47,8 +47,8 @@ describe("CICS AddToList csdGroup", () => {
             hostname: cmciProperties.host,
             port: cmciProperties.port,
             type: "basic",
-            strictSSL: false,
-            protocol: testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/api/methods/define/Define.program.system.test.ts
+++ b/__tests__/__system__/api/methods/define/Define.program.system.test.ts
@@ -38,8 +38,8 @@ describe("CICS Define program", () => {
       hostname: cmciProperties.host,
       port: cmciProperties.port,
       type: "basic",
-      strictSSL: false,
-      protocol: testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+      rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+      protocol: cmciProperties.protocol as any || "https",
     });
   });
 

--- a/__tests__/__system__/api/methods/define/Define.transaction.system.test.ts
+++ b/__tests__/__system__/api/methods/define/Define.transaction.system.test.ts
@@ -38,8 +38,8 @@ describe("CICS Define transaction", () => {
             hostname: cmciProperties.host,
             port: cmciProperties.port,
             type: "basic",
-            strictSSL: false,
-            protocol: testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/api/methods/define/Define.urimap-client.system.test.ts
+++ b/__tests__/__system__/api/methods/define/Define.urimap-client.system.test.ts
@@ -49,8 +49,8 @@ describe("CICS Define client URImap", () => {
             hostname: cmciProperties.host,
             port: cmciProperties.port,
             type: "basic",
-            strictSSL: false,
-            protocol: testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/api/methods/define/Define.urimap-pipeline.system.test.ts
+++ b/__tests__/__system__/api/methods/define/Define.urimap-pipeline.system.test.ts
@@ -49,8 +49,8 @@ describe("CICS Define pipeline URImap", () => {
             hostname: cmciProperties.host,
             port: cmciProperties.port,
             type: "basic",
-            strictSSL: false,
-            protocol: testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/api/methods/define/Define.urimap-server.system.test.ts
+++ b/__tests__/__system__/api/methods/define/Define.urimap-server.system.test.ts
@@ -49,8 +49,8 @@ describe("CICS Define server URImap", () => {
             hostname: cmciProperties.host,
             port: cmciProperties.port,
             type: "basic",
-            strictSSL: false,
-            protocol: testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/api/methods/define/Define.webservice.system.test.ts
+++ b/__tests__/__system__/api/methods/define/Define.webservice.system.test.ts
@@ -38,8 +38,8 @@ describe("CICS Define web service", () => {
             hostname: cmciProperties.host,
             port: cmciProperties.port,
             type: "basic",
-            strictSSL: false,
-            protocol: testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/api/methods/delete/Delete.program.system.test.ts
+++ b/__tests__/__system__/api/methods/delete/Delete.program.system.test.ts
@@ -38,8 +38,8 @@ describe("CICS Delete program", () => {
             hostname: cmciProperties.host,
             port: cmciProperties.port,
             type: "basic",
-            strictSSL: false,
-            protocol:  testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/api/methods/delete/Delete.transaction.system.test.ts
+++ b/__tests__/__system__/api/methods/delete/Delete.transaction.system.test.ts
@@ -38,8 +38,8 @@ describe("CICS Delete transaction", () => {
             hostname: cmciProperties.host,
             port: cmciProperties.port,
             type: "basic",
-            strictSSL: false,
-            protocol:  testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/api/methods/delete/Delete.urimap.system.test.ts
+++ b/__tests__/__system__/api/methods/delete/Delete.urimap.system.test.ts
@@ -38,8 +38,8 @@ describe("CICS Delete URImap", () => {
             hostname: cmciProperties.host,
             port: cmciProperties.port,
             type: "basic",
-            strictSSL: false,
-            protocol: testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/api/methods/delete/Delete.webservice.system.test.ts
+++ b/__tests__/__system__/api/methods/delete/Delete.webservice.system.test.ts
@@ -38,8 +38,8 @@ describe("CICS Delete web service", () => {
             hostname: cmciProperties.host,
             port: cmciProperties.port,
             type: "basic",
-            strictSSL: false,
-            protocol: testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/api/methods/disable/Disable.urimap.system.test.ts
+++ b/__tests__/__system__/api/methods/disable/Disable.urimap.system.test.ts
@@ -45,8 +45,8 @@ describe("CICS Disable URImap", () => {
             hostname: cmciProperties.host,
             port: cmciProperties.port,
             type: "basic",
-            strictSSL: false,
-            protocol: testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/api/methods/discard/Discard.program.system.test.ts
+++ b/__tests__/__system__/api/methods/discard/Discard.program.system.test.ts
@@ -38,8 +38,8 @@ describe("CICS Discard program", () => {
             hostname: cmciProperties.host,
             port: cmciProperties.port,
             type: "basic",
-            strictSSL: false,
-            protocol:  testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/api/methods/discard/Discard.transaction.system.test.ts
+++ b/__tests__/__system__/api/methods/discard/Discard.transaction.system.test.ts
@@ -38,8 +38,8 @@ describe("CICS Discard transaction", () => {
             hostname: cmciProperties.host,
             port: cmciProperties.port,
             type: "basic",
-            strictSSL: false,
-            protocol:  testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/api/methods/discard/Discard.urimap.system.test.ts
+++ b/__tests__/__system__/api/methods/discard/Discard.urimap.system.test.ts
@@ -44,8 +44,8 @@ describe("CICS Discard URImap", () => {
             hostname: cmciProperties.host,
             port: cmciProperties.port,
             type: "basic",
-            strictSSL: false,
-            protocol: testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/api/methods/enable/Enable.urimap.system.test.ts
+++ b/__tests__/__system__/api/methods/enable/Enable.urimap.system.test.ts
@@ -45,8 +45,8 @@ describe("CICS Enable URImap", () => {
             hostname: cmciProperties.host,
             port: cmciProperties.port,
             type: "basic",
-            strictSSL: false,
-            protocol: testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/api/methods/get/Get.resource.system.test.ts
+++ b/__tests__/__system__/api/methods/get/Get.resource.system.test.ts
@@ -35,8 +35,8 @@ describe("CICS Get resource", () => {
             hostname: cmciProperties.host,
             port: cmciProperties.port,
             type: "basic",
-            strictSSL: false,
-            protocol:  testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/api/methods/install/Install.program.system.test.ts
+++ b/__tests__/__system__/api/methods/install/Install.program.system.test.ts
@@ -38,8 +38,8 @@ describe("CICS Install program", () => {
             hostname: cmciProperties.host,
             port: cmciProperties.port,
             type: "basic",
-            strictSSL: false,
-            protocol:  testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/api/methods/install/Install.transaction.system.test.ts
+++ b/__tests__/__system__/api/methods/install/Install.transaction.system.test.ts
@@ -40,8 +40,8 @@ describe("CICS Install transaction", () => {
             hostname: cmciProperties.host,
             port: cmciProperties.port,
             type: "basic",
-            strictSSL: false,
-            protocol:  testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/api/methods/install/Install.urimap.system.test.ts
+++ b/__tests__/__system__/api/methods/install/Install.urimap.system.test.ts
@@ -45,8 +45,8 @@ describe("CICS Install URImap", () => {
             hostname: cmciProperties.host,
             port: cmciProperties.port,
             type: "basic",
-            strictSSL: false,
-            protocol: testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/api/methods/refresh/Refresh.program.system.test.ts
+++ b/__tests__/__system__/api/methods/refresh/Refresh.program.system.test.ts
@@ -38,8 +38,8 @@ describe("CICS Refresh program", () => {
             hostname: cmciProperties.host,
             port: cmciProperties.port,
             type: "basic",
-            strictSSL: false,
-            protocol:  testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/api/methods/remove-from-list/RemoveFromList.csdGroup.system.test.ts
+++ b/__tests__/__system__/api/methods/remove-from-list/RemoveFromList.csdGroup.system.test.ts
@@ -47,8 +47,8 @@ describe("CICS RemoveFromList csdGroup", () => {
             hostname: cmciProperties.host,
             port: cmciProperties.port,
             type: "basic",
-            strictSSL: false,
-            protocol: testEnvironment.systemTestProperties.cmci.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/cli/define/program/cli.define.program.system.test.ts
+++ b/__tests__/__system__/cli/define/program/cli.define.program.system.test.ts
@@ -54,8 +54,8 @@ describe("CICS define program command", () => {
             port: cmciProperties.port,
             user: cmciProperties.user,
             password: cmciProperties.password,
-            strictSSL: false,
-            protocol: "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
 
         return CicsCmciRestClient.deleteExpectParsedXml(session,

--- a/__tests__/__system__/cli/define/transaction/cli.define.transaction.system.test.ts
+++ b/__tests__/__system__/cli/define/transaction/cli.define.transaction.system.test.ts
@@ -54,8 +54,8 @@ describe("CICS define transaction command", () => {
             port: cmciProperties.port,
             user: cmciProperties.user,
             password: cmciProperties.password,
-            strictSSL: false,
-            protocol: cmciProperties.protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
 
         return CicsCmciRestClient.deleteExpectParsedXml(session,

--- a/__tests__/__system__/cli/define/urimap-client/cli.define.urimap.client.system.test.ts
+++ b/__tests__/__system__/cli/define/urimap-client/cli.define.urimap.client.system.test.ts
@@ -51,8 +51,8 @@ describe("CICS define urimap-client command", () => {
             port: cmciProperties.port,
             user: cmciProperties.user,
             password: cmciProperties.password,
-            strictSSL: false,
-            protocol: "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/cli/define/urimap-pipeline/cli.define.urimap.pipeline.system.test.ts
+++ b/__tests__/__system__/cli/define/urimap-pipeline/cli.define.urimap.pipeline.system.test.ts
@@ -50,8 +50,8 @@ describe("CICS define urimap-pipeline command", () => {
             port: cmciProperties.port,
             user: cmciProperties.user,
             password: cmciProperties.password,
-            strictSSL: false,
-            protocol: "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/cli/define/urimap-server/cli.define.urimap.server.system.test.ts
+++ b/__tests__/__system__/cli/define/urimap-server/cli.define.urimap.server.system.test.ts
@@ -50,8 +50,8 @@ describe("CICS define urimap-server command", () => {
             port: cmciProperties.port,
             user: cmciProperties.user,
             password: cmciProperties.password,
-            strictSSL: false,
-            protocol: "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/cli/define/webservice/cli.define.webservice.system.test.ts
+++ b/__tests__/__system__/cli/define/webservice/cli.define.webservice.system.test.ts
@@ -50,8 +50,8 @@ describe("CICS define web service command", () => {
             port: cmciProperties.port,
             user: cmciProperties.user,
             password: cmciProperties.password,
-            strictSSL: false,
-            protocol: "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
     });
 

--- a/__tests__/__system__/cli/discard/program/cli.discard.program.system.test.ts
+++ b/__tests__/__system__/cli/discard/program/cli.discard.program.system.test.ts
@@ -55,8 +55,8 @@ describe("CICS discard program command", () => {
             port: cmciProperties.port,
             user: cmciProperties.user,
             password: cmciProperties.password,
-            strictSSL: false,
-            protocol: "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
 
         return CicsCmciRestClient.deleteExpectParsedXml(session,

--- a/__tests__/__system__/cli/discard/transaction/cli.discard.transaction.system.test.ts
+++ b/__tests__/__system__/cli/discard/transaction/cli.discard.transaction.system.test.ts
@@ -56,8 +56,8 @@ describe("CICS discard transaction command", () => {
             port: cmciProperties.port,
             user: cmciProperties.user,
             password: cmciProperties.password,
-            strictSSL: false,
-            protocol: "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
 
         return CicsCmciRestClient.deleteExpectParsedXml(session,

--- a/__tests__/__system__/cli/install/program/cli.install.program.system.test.ts
+++ b/__tests__/__system__/cli/install/program/cli.install.program.system.test.ts
@@ -55,8 +55,8 @@ describe("CICS install program command", () => {
             port: cmciProperties.port,
             user: cmciProperties.user,
             password: cmciProperties.password,
-            strictSSL: false,
-            protocol: protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
 
         return CicsCmciRestClient.deleteExpectParsedXml(session,
@@ -72,8 +72,8 @@ describe("CICS install program command", () => {
             port: cmciProperties.port,
             user: cmciProperties.user,
             password: cmciProperties.password,
-            strictSSL: false,
-            protocol: protocol as any || "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
 
         return CicsCmciRestClient.deleteExpectParsedXml(deleteSession,

--- a/__tests__/__system__/cli/install/transaction/cli.install.transaction.system.test.ts
+++ b/__tests__/__system__/cli/install/transaction/cli.install.transaction.system.test.ts
@@ -55,8 +55,8 @@ describe("CICS install transaction command", () => {
             port: cmciProperties.port,
             user: cmciProperties.user,
             password: cmciProperties.password,
-            strictSSL: false,
-            protocol: "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
 
         return CicsCmciRestClient.deleteExpectParsedXml(session,
@@ -72,8 +72,8 @@ describe("CICS install transaction command", () => {
             port: cmciProperties.port,
             user: cmciProperties.user,
             password: cmciProperties.password,
-            strictSSL: false,
-            protocol: "http",
+            rejectUnauthorized: cmciProperties.rejectUnauthorized || false,
+            protocol: cmciProperties.protocol as any || "https",
         });
 
         return CicsCmciRestClient.deleteExpectParsedXml(deleteSession,

--- a/__tests__/__system__/cli/refresh/program/cli.refresh.program.system.test.ts
+++ b/__tests__/__system__/cli/refresh/program/cli.refresh.program.system.test.ts
@@ -23,6 +23,7 @@ let host: string;
 let port: number;
 let user: string;
 let password: string;
+let ru: boolean;
 
 describe("CICS refresh program command", () => {
 
@@ -38,6 +39,7 @@ describe("CICS refresh program command", () => {
         port = TEST_ENVIRONMENT.systemTestProperties.cmci.port;
         user = TEST_ENVIRONMENT.systemTestProperties.cmci.user;
         password = TEST_ENVIRONMENT.systemTestProperties.cmci.password;
+        ru = TEST_ENVIRONMENT.systemTestProperties.cmci.rejectUnauthorized || false;
 
         session = new Session({
             user,
@@ -45,8 +47,8 @@ describe("CICS refresh program command", () => {
             hostname: host,
             port,
             type: "basic",
-            strictSSL: false,
-            protocol: "http",
+            rejectUnauthorized: ru,
+            protocol: TEST_ENVIRONMENT.systemTestProperties.cmci.protocol as any || "https",
         });
     });
 


### PR DESCRIPTION
Updates the system tests to use either the protocol specified in the custom_properties.json file in all tests, or use HTTPS if none is specified. This prepares the project for coming changes to default the CICS Plugin to use secure (HTTPS) connections.

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>