### PR TITLE
Breaking Change: Default CICS Plugin to use HTTPS to connect to CMCI

### DIFF
--- a/__tests__/__snapshots__/imperative.test.ts.snap
+++ b/__tests__/__snapshots__/imperative.test.ts.snap
@@ -79,7 +79,7 @@ Object {
                   "https",
                 ],
               },
-              "defaultValue": "http",
+              "defaultValue": "https",
               "description": "Specifies CMCI protocol (http or https).",
               "group": "Cics Connection Options",
               "name": "protocol",

--- a/__tests__/__system__/cli/add-to-list/csdGroup/__snapshots__/cli.add-to-list.csdGroup.system.test.ts.snap
+++ b/__tests__/__system__/cli/add-to-list/csdGroup/__snapshots__/cli.add-to-list.csdGroup.system.test.ts.snap
@@ -72,7 +72,7 @@ exports[`CICS add-to-list csdGroup command should be able to display the help 1`
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__system__/cli/define/program/__snapshots__/cli.define.program.system.test.ts.snap
+++ b/__tests__/__system__/cli/define/program/__snapshots__/cli.define.program.system.test.ts.snap
@@ -72,7 +72,7 @@ exports[`CICS define program command should be able to display the help 1`] = `
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__system__/cli/define/transaction/__snapshots__/cli.define.transaction.system.test.ts.snap
+++ b/__tests__/__system__/cli/define/transaction/__snapshots__/cli.define.transaction.system.test.ts.snap
@@ -77,7 +77,7 @@ exports[`CICS define transaction command should be able to display the help 1`] 
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__system__/cli/define/urimap-client/__snapshots__/cli.define.urimap.client.system.test.ts.snap
+++ b/__tests__/__system__/cli/define/urimap-client/__snapshots__/cli.define.urimap.client.system.test.ts.snap
@@ -100,7 +100,7 @@ exports[`CICS define urimap-client command should be able to display the help 1`
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__system__/cli/define/urimap-pipeline/__snapshots__/cli.define.urimap.pipeline.system.test.ts.snap
+++ b/__tests__/__system__/cli/define/urimap-pipeline/__snapshots__/cli.define.urimap.pipeline.system.test.ts.snap
@@ -116,7 +116,7 @@ exports[`CICS define urimap-pipeline command should be able to display the help 
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__system__/cli/define/urimap-server/__snapshots__/cli.define.urimap.server.system.test.ts.snap
+++ b/__tests__/__system__/cli/define/urimap-server/__snapshots__/cli.define.urimap.server.system.test.ts.snap
@@ -104,7 +104,7 @@ exports[`CICS define urimap-server command should be able to display the help 1`
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__system__/cli/define/webservice/__snapshots__/cli.define.webservice.system.test.ts.snap
+++ b/__tests__/__system__/cli/define/webservice/__snapshots__/cli.define.webservice.system.test.ts.snap
@@ -97,7 +97,7 @@ exports[`CICS define web service command should be able to display the help 1`] 
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__system__/cli/delete/program/__snapshots__/cli.delete.program.system.test.ts.snap
+++ b/__tests__/__system__/cli/delete/program/__snapshots__/cli.delete.program.system.test.ts.snap
@@ -72,7 +72,7 @@ exports[`CICS delete program command should be able to display the help 1`] = `
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__system__/cli/delete/transaction/__snapshots__/cli.delete.transaction.system.test.ts.snap
+++ b/__tests__/__system__/cli/delete/transaction/__snapshots__/cli.delete.transaction.system.test.ts.snap
@@ -72,7 +72,7 @@ exports[`CICS delete transaction command should be able to display the help 1`] 
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__system__/cli/delete/urimap/__snapshots__/cli.delete.urimap.system.test.ts.snap
+++ b/__tests__/__system__/cli/delete/urimap/__snapshots__/cli.delete.urimap.system.test.ts.snap
@@ -68,7 +68,7 @@ exports[`CICS delete urimap command should be able to display the help 1`] = `
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__system__/cli/delete/webservice/__snapshots__/cli.delete.webservice.system.test.ts.snap
+++ b/__tests__/__system__/cli/delete/webservice/__snapshots__/cli.delete.webservice.system.test.ts.snap
@@ -68,7 +68,7 @@ exports[`CICS delete web service command should be able to display the help 1`] 
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__system__/cli/disable/urimap/__snapshots__/cli.disable.urimap.system.test.ts.snap
+++ b/__tests__/__system__/cli/disable/urimap/__snapshots__/cli.disable.urimap.system.test.ts.snap
@@ -63,7 +63,7 @@ exports[`CICS disable urimap command should be able to display the help 1`] = `
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__system__/cli/discard/program/__snapshots__/cli.discard.program.system.test.ts.snap
+++ b/__tests__/__system__/cli/discard/program/__snapshots__/cli.discard.program.system.test.ts.snap
@@ -67,7 +67,7 @@ exports[`CICS discard program command should be able to display the help 1`] = `
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__system__/cli/discard/transaction/__snapshots__/cli.discard.transaction.system.test.ts.snap
+++ b/__tests__/__system__/cli/discard/transaction/__snapshots__/cli.discard.transaction.system.test.ts.snap
@@ -67,7 +67,7 @@ exports[`CICS discard transaction command should be able to display the help 1`]
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__system__/cli/discard/urimap/__snapshots__/cli.discard.urimap.system.test.ts.snap
+++ b/__tests__/__system__/cli/discard/urimap/__snapshots__/cli.discard.urimap.system.test.ts.snap
@@ -63,7 +63,7 @@ exports[`CICS discard urimap command should be able to display the help 1`] = `
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__system__/cli/enable/urimap/__snapshots__/cli.enable.urimap.system.test.ts.snap
+++ b/__tests__/__system__/cli/enable/urimap/__snapshots__/cli.enable.urimap.system.test.ts.snap
@@ -63,7 +63,7 @@ exports[`CICS enable urimap command should be able to display the help 1`] = `
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__system__/cli/get/resource/__snapshots__/cli.get.resource.system.test.ts.snap
+++ b/__tests__/__system__/cli/get/resource/__snapshots__/cli.get.resource.system.test.ts.snap
@@ -75,7 +75,7 @@ exports[`cics get resource should display the help 1`] = `
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__system__/cli/install/program/__snapshots__/cli.install.program.system.test.ts.snap
+++ b/__tests__/__system__/cli/install/program/__snapshots__/cli.install.program.system.test.ts.snap
@@ -72,7 +72,7 @@ exports[`CICS install program command should be able to display the help 1`] = `
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__system__/cli/install/transaction/__snapshots__/cli.install.transaction.system.test.ts.snap
+++ b/__tests__/__system__/cli/install/transaction/__snapshots__/cli.install.transaction.system.test.ts.snap
@@ -72,7 +72,7 @@ exports[`CICS install transaction command should be able to display the help 1`]
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__system__/cli/install/urimap/__snapshots__/cli.install.urimap.system.test.ts.snap
+++ b/__tests__/__system__/cli/install/urimap/__snapshots__/cli.install.urimap.system.test.ts.snap
@@ -68,7 +68,7 @@ exports[`CICS install urimap command should be able to display the help 1`] = `
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__system__/cli/profiles/__snapshots__/cli.profile.create.cics-profile.integration.test.ts.snap
+++ b/__tests__/__system__/cli/profiles/__snapshots__/cli.profile.create.cics-profile.integration.test.ts.snap
@@ -78,7 +78,7 @@ exports[`Create cics Profile Success scenarios should display create cics profil
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  GLOBAL OPTIONS

--- a/__tests__/__system__/cli/refresh/program/__snapshots__/cli.refresh.program.system.test.ts.snap
+++ b/__tests__/__system__/cli/refresh/program/__snapshots__/cli.refresh.program.system.test.ts.snap
@@ -67,7 +67,7 @@ exports[`CICS refresh program command should be able to display the help 1`] = `
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/__system__/cli/remove-from-list/csdGroup/__snapshots__/cli.remove-from-list.csdGroup.system.test.ts.snap
+++ b/__tests__/__system__/cli/remove-from-list/csdGroup/__snapshots__/cli.remove-from-list.csdGroup.system.test.ts.snap
@@ -72,7 +72,7 @@ exports[`CICS remove-from-list csdGroup command should be able to display the he
 
       Specifies CMCI protocol (http or https).
 
-      Default value: http
+      Default value: https
       Allowed values: http, https
 
  PROFILE OPTIONS

--- a/__tests__/cli/add-to-list/__snapshots__/AddToList.definition.unit.test.ts.snap
+++ b/__tests__/cli/add-to-list/__snapshots__/AddToList.definition.unit.test.ts.snap
@@ -79,7 +79,7 @@ Object {
               "https",
             ],
           },
-          "defaultValue": "http",
+          "defaultValue": "https",
           "description": "Specifies CMCI protocol (http or https).",
           "group": "Cics Connection Options",
           "name": "protocol",

--- a/__tests__/cli/define/__snapshots__/Define.definition.unit.test.ts.snap
+++ b/__tests__/cli/define/__snapshots__/Define.definition.unit.test.ts.snap
@@ -79,7 +79,7 @@ Object {
               "https",
             ],
           },
-          "defaultValue": "http",
+          "defaultValue": "https",
           "description": "Specifies CMCI protocol (http or https).",
           "group": "Cics Connection Options",
           "name": "protocol",

--- a/__tests__/cli/delete/__snapshots__/Delete.definition.unit.test.ts.snap
+++ b/__tests__/cli/delete/__snapshots__/Delete.definition.unit.test.ts.snap
@@ -79,7 +79,7 @@ Object {
               "https",
             ],
           },
-          "defaultValue": "http",
+          "defaultValue": "https",
           "description": "Specifies CMCI protocol (http or https).",
           "group": "Cics Connection Options",
           "name": "protocol",

--- a/__tests__/cli/disable/__snapshots__/Disable.definition.unit.test.ts.snap
+++ b/__tests__/cli/disable/__snapshots__/Disable.definition.unit.test.ts.snap
@@ -76,7 +76,7 @@ Object {
               "https",
             ],
           },
-          "defaultValue": "http",
+          "defaultValue": "https",
           "description": "Specifies CMCI protocol (http or https).",
           "group": "Cics Connection Options",
           "name": "protocol",

--- a/__tests__/cli/discard/__snapshots__/Discard.definition.unit.test.ts.snap
+++ b/__tests__/cli/discard/__snapshots__/Discard.definition.unit.test.ts.snap
@@ -79,7 +79,7 @@ Object {
               "https",
             ],
           },
-          "defaultValue": "http",
+          "defaultValue": "https",
           "description": "Specifies CMCI protocol (http or https).",
           "group": "Cics Connection Options",
           "name": "protocol",

--- a/__tests__/cli/enable/__snapshots__/Enable.definition.unit.test.ts.snap
+++ b/__tests__/cli/enable/__snapshots__/Enable.definition.unit.test.ts.snap
@@ -79,7 +79,7 @@ Object {
               "https",
             ],
           },
-          "defaultValue": "http",
+          "defaultValue": "https",
           "description": "Specifies CMCI protocol (http or https).",
           "group": "Cics Connection Options",
           "name": "protocol",

--- a/__tests__/cli/get/__snapshots__/Get.definition.unit.test.ts.snap
+++ b/__tests__/cli/get/__snapshots__/Get.definition.unit.test.ts.snap
@@ -76,7 +76,7 @@ Object {
               "https",
             ],
           },
-          "defaultValue": "http",
+          "defaultValue": "https",
           "description": "Specifies CMCI protocol (http or https).",
           "group": "Cics Connection Options",
           "name": "protocol",

--- a/__tests__/cli/install/__snapshots__/Install.definition.unit.test.ts.snap
+++ b/__tests__/cli/install/__snapshots__/Install.definition.unit.test.ts.snap
@@ -79,7 +79,7 @@ Object {
               "https",
             ],
           },
-          "defaultValue": "http",
+          "defaultValue": "https",
           "description": "Specifies CMCI protocol (http or https).",
           "group": "Cics Connection Options",
           "name": "protocol",

--- a/__tests__/cli/install/transaction/Transaction.handler.unit.test.ts
+++ b/__tests__/cli/install/transaction/Transaction.handler.unit.test.ts
@@ -22,7 +22,7 @@ const port = "43443";
 const user = "someone";
 const password = "somesecret";
 const rejectUnauthorized = false;
-const protocol = "http";
+const protocol = "https";
 
 const PROFILE_MAP = new Map<string, IProfile[]>();
 PROFILE_MAP.set(

--- a/__tests__/cli/refresh/__snapshots__/Refresh.definition.unit.test.ts.snap
+++ b/__tests__/cli/refresh/__snapshots__/Refresh.definition.unit.test.ts.snap
@@ -79,7 +79,7 @@ Object {
               "https",
             ],
           },
-          "defaultValue": "http",
+          "defaultValue": "https",
           "description": "Specifies CMCI protocol (http or https).",
           "group": "Cics Connection Options",
           "name": "protocol",

--- a/__tests__/cli/refresh/program/Program.handler.unit.test.ts
+++ b/__tests__/cli/refresh/program/Program.handler.unit.test.ts
@@ -21,7 +21,7 @@ const host = "somewhere.com";
 const port = "43443";
 const user = "someone";
 const password = "somesecret";
-const protocol = "http";
+const protocol = "https";
 
 const PROFILE_MAP = new Map<string, IProfile[]>();
 PROFILE_MAP.set(
@@ -120,7 +120,7 @@ describe("RefreshProgramHandler", () => {
                 user: testProfile.user,
                 password: testProfile.password,
                 rejectUnauthorized: false,
-                protocol: "http",
+                protocol: "https",
             }),
             {
                 name: programName,

--- a/__tests__/cli/remove-from-list/__snapshots__/RemoveFromList.definition.unit.test.ts.snap
+++ b/__tests__/cli/remove-from-list/__snapshots__/RemoveFromList.definition.unit.test.ts.snap
@@ -79,7 +79,7 @@ Object {
               "https",
             ],
           },
-          "defaultValue": "http",
+          "defaultValue": "https",
           "description": "Specifies CMCI protocol (http or https).",
           "group": "Cics Connection Options",
           "name": "protocol",

--- a/src/cli/CicsSession.ts
+++ b/src/cli/CicsSession.ts
@@ -86,7 +86,7 @@ export class CicsSession {
         aliases: ["o"],
         description: "Specifies CMCI protocol (http or https).",
         type: "string",
-        defaultValue: "http",
+        defaultValue: "https",
         required: true,
         allowableValues: {values: ["http", "https"], caseSensitive: false},
         group: CicsSession.CICS_CONNECTION_OPTION_GROUP
@@ -120,7 +120,7 @@ export class CicsSession {
             user: profile.user,
             password: profile.pass,
             basePath: profile.basePath,
-            protocol: profile.protocol || "http",
+            protocol: profile.protocol || "https",
         });
     }
 
@@ -140,7 +140,7 @@ export class CicsSession {
             password: args.password,
             basePath: args.basePath,
             rejectUnauthorized: args.rejectUnauthorized,
-            protocol: args.protocol || "http",
+            protocol: args.protocol || "https",
         });
     }
 


### PR DESCRIPTION
As part of moving to security by default, change the CICS plugin to use HTTPS for the connection to CMCI when no protocol is specified. This can be overridden by specifying `--protocol http` or `-o http` during profile creation or while issuing commands. Because this changes the default behavior of the CICS Plugin and will result in the need for people to update profiles/scripts to use HTTP, this is a breaking change.

Resolves #77 

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>