### PR TITLE
Apiml conn lookup next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® CICS® Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Add apimlConnLookup properties to enable auto-config through APIML. A valid apiId must still be identified.
+
 ## `5.0.0-next.202104261510`
 
 - Remove @zowe/cli peer dependency to better support NPM v7

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ node('ca-jenkins-agent') {
     // Initialize the pipeline
     def pipeline = new NodeJSPipeline(this)
 
-    // Build admins, users that can approve the build and receieve emails for 
+    // Build admins, users that can approve the build and receieve emails for
     // all protected branch builds.
     pipeline.admins.add("tucker01", "gejohnston", "zfernand0", "mikebauerca", "markackert", "dkelosky")
 
@@ -33,7 +33,7 @@ node('ca-jenkins-agent') {
     // Protected branch property definitions
     pipeline.protectedBranches.addMap([
         [name: "master", tag: "latest", level: SemverLevel.MINOR, dependencies: ["@zowe/imperative": "latest"], aliasTags: ["zowe-v1-lts"]],
-        [name: "next", tag: "next", prerelease: "next", dependencies: ["@zowe/imperative": "next"]],
+        [name: "next", tag: "next", prerelease: "next"],
         //[name: "master", tag: "latest", dependencies: ["@zowe/imperative": "latest"]],
         //[name: "zowe-v1-lts", tag: "zowe-v1-lts", dependencies: ["@zowe/imperative": "zowe-v1-lts"]],
         [name: "lts-incremental", tag: "lts-incremental", level: SemverLevel.PATCH, dependencies: ["@brightside/imperative": "lts-incremental"]],
@@ -86,7 +86,7 @@ node('ca-jenkins-agent') {
     def TEST_ROOT = "__tests__/__results__"
     def UNIT_TEST_ROOT = "$TEST_ROOT/unit"
     def UNIT_JUNIT_OUTPUT = "$UNIT_TEST_ROOT/junit.xml"
-    
+
     // Perform a unit test and capture the results
     pipeline.test(
         name: "Unit",

--- a/__tests__/__snapshots__/imperative.test.ts.snap
+++ b/__tests__/__snapshots__/imperative.test.ts.snap
@@ -2,6 +2,13 @@
 
 exports[`imperative config should match the snapshot 1`] = `
 Object {
+  "apimlConnLookup": Array [
+    Object {
+      "apiId": "place_the_cics_apiId_here",
+      "connProfType": "cics",
+      "gatewayUrl": "api/v1",
+    },
+  ],
   "commandModuleGlobs": Array [
     "**/cli/*/*.definition!(.d).*s",
   ],

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "xml2js": "0.4.19"
   },
   "peerDependencies": {
-    "@zowe/imperative": "5.0.0-next.202104081433"
+    "@zowe/imperative": ">=5.0.0-next.202106221817 <5.0.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^5.0.5",
@@ -53,8 +53,8 @@
     "@types/node": "^8.10.45",
     "@types/xml2js": "^0.4.4",
     "@types/yargs": "8.0.2",
-    "@zowe/cli-test-utils": "^7.0.0-next.202104132114",
-    "@zowe/imperative": "5.0.0-next.202104142114",
+    "@zowe/cli-test-utils": ">=7.0.0-next.202106242030 <8.0.0",
+    "@zowe/imperative": ">=5.0.0-next <6.0.0",
     "env-cmd": "^8.0.2",
     "fs-extra": "^5.0.0",
     "glob": "^7.1.3",

--- a/src/imperative.ts
+++ b/src/imperative.ts
@@ -20,6 +20,13 @@ const config: IImperativeConfig = {
     productDisplayName: PluginConstants.PLUGIN_NAME,
     name: PluginConstants.PLUGIN_GROUP_NAME,
     pluginHealthCheck: "./lib/healthCheck.handler",
+    apimlConnLookup: [
+        {
+          apiId: "place_the_cics_apiId_here",
+          gatewayUrl: "api/v1",
+          connProfType: "cics"
+        }
+    ],
     profiles: [
         {
             type: "cics",


### PR DESCRIPTION
Add apimlConnLookup properties to enable auto-config through APIML.
A valid apiId for CICS must still be identified.