### PR TITLE
Fix unit tests failing in Node 16

### DIFF
--- a/__tests__/api/methods/add-to-list/AddToList.csdGroup.unit.test.ts
+++ b/__tests__/api/methods/add-to-list/AddToList.csdGroup.unit.test.ts
@@ -53,7 +53,7 @@ describe("CMCI - Add csdGroup to list", () => {
 
             expect(response).toBeUndefined();
             expect(error).toBeDefined();
-            expect(error.message).toContain("Cannot read property 'name' of undefined");
+            expect(error.message).toMatch(/Cannot read (property 'name' of undefined|properties of undefined \(reading 'name'\))/);
         });
 
         it("should throw error if csdGroup name is not defined", async () => {

--- a/__tests__/api/methods/define/Define.program.unit.test.ts
+++ b/__tests__/api/methods/define/Define.program.unit.test.ts
@@ -53,7 +53,7 @@ describe("CMCI - Define program", () => {
 
             expect(response).toBeUndefined();
             expect(error).toBeDefined();
-            expect(error.message).toContain("Cannot read property 'name' of undefined");
+            expect(error.message).toMatch(/Cannot read (property 'name' of undefined|properties of undefined \(reading 'name'\))/);
         });
 
         it("should throw error if program name is not defined", async () => {

--- a/__tests__/api/methods/define/Define.transaction.unit.test.ts
+++ b/__tests__/api/methods/define/Define.transaction.unit.test.ts
@@ -55,7 +55,7 @@ describe("CMCI - Define transaction", () => {
 
             expect(response).toBeUndefined();
             expect(error).toBeDefined();
-            expect(error.message).toContain("Cannot read property 'name' of undefined");
+            expect(error.message).toMatch(/Cannot read (property 'name' of undefined|properties of undefined \(reading 'name'\))/);
         });
 
         it("should throw error if transaction name is not defined", async () => {

--- a/__tests__/api/methods/define/Define.urimap-client.unit.test.ts
+++ b/__tests__/api/methods/define/Define.urimap-client.unit.test.ts
@@ -62,7 +62,7 @@ describe("CMCI - Define client URIMap", () => {
 
             expect(response).toBeUndefined();
             expect(error).toBeDefined();
-            expect(error.message).toContain("Cannot read property 'name' of undefined");
+            expect(error.message).toMatch(/Cannot read (property 'name' of undefined|properties of undefined \(reading 'name'\))/);
         });
 
         it("should throw error if URIMap name is not defined", async () => {

--- a/__tests__/api/methods/define/Define.urimap-pipeline.unit.test.ts
+++ b/__tests__/api/methods/define/Define.urimap-pipeline.unit.test.ts
@@ -65,7 +65,7 @@ describe("CMCI - Define pipeline URIMap", () => {
 
             expect(response).toBeUndefined();
             expect(error).toBeDefined();
-            expect(error.message).toContain("Cannot read property 'name' of undefined");
+            expect(error.message).toMatch(/Cannot read (property 'name' of undefined|properties of undefined \(reading 'name'\))/);
         });
 
         it("should throw error if URIMap name is not defined", async () => {

--- a/__tests__/api/methods/define/Define.urimap-server.unit.test.ts
+++ b/__tests__/api/methods/define/Define.urimap-server.unit.test.ts
@@ -63,7 +63,7 @@ describe("CMCI - Define server URIMap", () => {
 
             expect(response).toBeUndefined();
             expect(error).toBeDefined();
-            expect(error.message).toContain("Cannot read property 'name' of undefined");
+            expect(error.message).toMatch(/Cannot read (property 'name' of undefined|properties of undefined \(reading 'name'\))/);
         });
 
         it("should throw error if URIMap name is not defined", async () => {

--- a/__tests__/api/methods/define/Define.webservice.unit.test.ts
+++ b/__tests__/api/methods/define/Define.webservice.unit.test.ts
@@ -58,7 +58,7 @@ describe("CMCI - Define web service", () => {
 
             expect(response).toBeUndefined();
             expect(error).toBeDefined();
-            expect(error.message).toContain("Cannot read property 'name' of undefined");
+            expect(error.message).toMatch(/Cannot read (property 'name' of undefined|properties of undefined \(reading 'name'\))/);
         });
 
         it("should throw error if web service name is not defined", async () => {

--- a/__tests__/api/methods/delete/Delete.program.unit.test.ts
+++ b/__tests__/api/methods/delete/Delete.program.unit.test.ts
@@ -58,7 +58,7 @@ describe("CMCI - Delete program", () => {
 
             expect(response).toBeUndefined();
             expect(error).toBeDefined();
-            expect(error.message).toContain("Cannot read property 'name' of undefined");
+            expect(error.message).toMatch(/Cannot read (property 'name' of undefined|properties of undefined \(reading 'name'\))/);
         });
 
         it("should throw error if program name is not defined", async () => {

--- a/__tests__/api/methods/delete/Delete.transaction.unit.test.ts
+++ b/__tests__/api/methods/delete/Delete.transaction.unit.test.ts
@@ -60,7 +60,7 @@ describe("CMCI - Discard transaction", () => {
 
             expect(response).toBeUndefined();
             expect(error).toBeDefined();
-            expect(error.message).toContain("Cannot read property 'name' of undefined");
+            expect(error.message).toMatch(/Cannot read (property 'name' of undefined|properties of undefined \(reading 'name'\))/);
         });
 
         it("should throw error if transaction name is not defined", async () => {

--- a/__tests__/api/methods/discard/Discard.program.unit.test.ts
+++ b/__tests__/api/methods/discard/Discard.program.unit.test.ts
@@ -51,7 +51,7 @@ describe("CMCI - Discard program", () => {
 
             expect(response).toBeUndefined();
             expect(error).toBeDefined();
-            expect(error.message).toContain("Cannot read property 'name' of undefined");
+            expect(error.message).toMatch(/Cannot read (property 'name' of undefined|properties of undefined \(reading 'name'\))/);
         });
 
         it("should throw error if program name is not defined", async () => {

--- a/__tests__/api/methods/discard/Discard.transaction.unit.test.ts
+++ b/__tests__/api/methods/discard/Discard.transaction.unit.test.ts
@@ -60,7 +60,7 @@ describe("CMCI - Discard transaction", () => {
 
             expect(response).toBeUndefined();
             expect(error).toBeDefined();
-            expect(error.message).toContain("Cannot read property 'name' of undefined");
+            expect(error.message).toMatch(/Cannot read (property 'name' of undefined|properties of undefined \(reading 'name'\))/);
         });
 
         it("should throw error if transaction name is not defined", async () => {

--- a/__tests__/api/methods/get/Get.resource.unit.test.ts
+++ b/__tests__/api/methods/get/Get.resource.unit.test.ts
@@ -58,7 +58,7 @@ describe("CMCI - Get resource", () => {
 
             expect(response).toBeUndefined();
             expect(error).toBeDefined();
-            expect(error.message).toContain("Cannot read property 'name' of undefined");
+            expect(error.message).toMatch(/Cannot read (property 'name' of undefined|properties of undefined \(reading 'name'\))/);
         });
 
         it("should throw error if resource name is not defined", async () => {

--- a/__tests__/api/methods/install/Install.program.unit.test.ts
+++ b/__tests__/api/methods/install/Install.program.unit.test.ts
@@ -53,7 +53,7 @@ describe("CMCI - Install program", () => {
 
             expect(response).toBeUndefined();
             expect(error).toBeDefined();
-            expect(error.message).toContain("Cannot read property 'name' of undefined");
+            expect(error.message).toMatch(/Cannot read (property 'name' of undefined|properties of undefined \(reading 'name'\))/);
         });
 
         it("should throw error if program name is not defined", async () => {

--- a/__tests__/api/methods/install/Install.transaction.unit.test.ts
+++ b/__tests__/api/methods/install/Install.transaction.unit.test.ts
@@ -56,7 +56,7 @@ describe("CMCI - Install transaction", () => {
 
             expect(response).toBeUndefined();
             expect(error).toBeDefined();
-            expect(error.message).toContain("Cannot read property 'name' of undefined");
+            expect(error.message).toMatch(/Cannot read (property 'name' of undefined|properties of undefined \(reading 'name'\))/);
         });
 
         it("should throw error if transaction name is not defined", async () => {

--- a/__tests__/api/methods/refresh/Refresh.program.unit.test.ts
+++ b/__tests__/api/methods/refresh/Refresh.program.unit.test.ts
@@ -51,7 +51,7 @@ describe("CMCI - Refresh program", () => {
 
             expect(response).toBeUndefined();
             expect(error).toBeDefined();
-            expect(error.message).toContain("Cannot read property 'name' of undefined");
+            expect(error.message).toMatch(/Cannot read (property 'name' of undefined|properties of undefined \(reading 'name'\))/);
         });
 
         it("should throw error if program name is not defined", async () => {

--- a/__tests__/api/methods/remove-from-list/RemoveFromList.csdGroup.unit.test.ts
+++ b/__tests__/api/methods/remove-from-list/RemoveFromList.csdGroup.unit.test.ts
@@ -53,7 +53,7 @@ describe("CMCI - Remove csdGroup from list", () => {
 
             expect(response).toBeUndefined();
             expect(error).toBeDefined();
-            expect(error.message).toContain("Cannot read property 'name' of undefined");
+            expect(error.message).toMatch(/Cannot read (property 'name' of undefined|properties of undefined \(reading 'name'\))/);
         });
 
         it("should throw error if csdGroup name is not defined", async () => {


### PR DESCRIPTION
Thanks to @awharn for the workaround using `toMatch` in https://github.com/zowe/imperative/pull/666 🙂 